### PR TITLE
feat(infra): implementar design system com dark/light mode

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -3,3 +3,11 @@
     <NuxtPage />
   </div>
 </template>
+
+<script setup lang="ts">
+const { init } = useColorMode()
+
+onMounted(() => {
+  init()
+})
+</script>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,1 +1,105 @@
 @import 'tailwindcss';
+
+/* Dark mode via classe .dark (controle manual) */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ============================================
+   Design Tokens — Memorai
+   Dark-first, roxo como identidade, cyan pra IA
+   ============================================ */
+
+@theme {
+  /* Primary — Roxo (identidade) */
+  --color-primary-400: #A78BFA;
+  --color-primary-500: #7C3AED;
+  --color-primary-600: #6D28D9;
+  --color-primary-700: #5B21B6;
+  --color-primary-800: #4C1D95;
+  --color-primary-900: #3B0764;
+
+  /* Accent — Cyan/Teal (IA, elementos "smart") */
+  --color-accent-400: #22D3EE;
+  --color-accent-500: #06B6D4;
+  --color-accent-600: #0891B2;
+
+  /* Semânticas */
+  --color-success: #22C55E;
+  --color-danger: #EF4444;
+  --color-warning: #F59E0B;
+  --color-info: #38BDF8;
+
+  /* Fonte */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
+}
+
+/* ============================================
+   CSS Variables — mudam entre light/dark
+   ============================================ */
+
+:root {
+  /* Light mode (default quando sem .dark) */
+  --bg-primary: #FFFFFF;
+  --bg-secondary: #F9FAFB;
+  --bg-tertiary: #F3F4F6;
+  --text-primary: #111827;
+  --text-secondary: #4B5563;
+  --text-muted: #9CA3AF;
+  --border-default: #E5E7EB;
+  --border-strong: #D1D5DB;
+}
+
+.dark {
+  --bg-primary: #0B0F1A;
+  --bg-secondary: #111827;
+  --bg-tertiary: #1F2937;
+  --text-primary: #E5E7EB;
+  --text-secondary: #9CA3AF;
+  --text-muted: #6B7280;
+  --border-default: #1F2937;
+  --border-strong: #374151;
+}
+
+/* ============================================
+   Utilitários base
+   ============================================ */
+
+@utility bg-surface {
+  background-color: var(--bg-primary);
+}
+
+@utility bg-surface-secondary {
+  background-color: var(--bg-secondary);
+}
+
+@utility bg-surface-tertiary {
+  background-color: var(--bg-tertiary);
+}
+
+@utility text-base-primary {
+  color: var(--text-primary);
+}
+
+@utility text-base-secondary {
+  color: var(--text-secondary);
+}
+
+@utility text-base-muted {
+  color: var(--text-muted);
+}
+
+@utility border-base {
+  border-color: var(--border-default);
+}
+
+@utility border-strong {
+  border-color: var(--border-strong);
+}
+
+/* ============================================
+   Base styles
+   ============================================ */
+
+html {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}

--- a/app/composables/useColorMode.ts
+++ b/app/composables/useColorMode.ts
@@ -1,0 +1,30 @@
+export function useColorMode() {
+  const colorMode = useState<'light' | 'dark'>('color-mode', () => 'dark')
+
+  function toggle() {
+    colorMode.value = colorMode.value === 'dark' ? 'light' : 'dark'
+    apply()
+  }
+
+  function set(mode: 'light' | 'dark') {
+    colorMode.value = mode
+    apply()
+  }
+
+  function apply() {
+    if (import.meta.client) {
+      document.documentElement.classList.toggle('dark', colorMode.value === 'dark')
+      localStorage.setItem('color-mode', colorMode.value)
+    }
+  }
+
+  function init() {
+    if (import.meta.client) {
+      const saved = localStorage.getItem('color-mode') as 'light' | 'dark' | null
+      colorMode.value = saved ?? 'dark'
+      apply()
+    }
+  }
+
+  return { colorMode, toggle, set, init }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,12 +19,17 @@ export default defineNuxtConfig({
 
   app: {
     head: {
-      htmlAttrs: { lang: 'pt-BR' },
+      htmlAttrs: { lang: 'pt-BR', class: 'dark' },
       title: 'Memorai',
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { name: 'description', content: 'Memora aí — sua memória com IA' },
+      ],
+      link: [
+        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap' },
       ],
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@pinia/nuxt": "^0.11.3",
         "@tailwindcss/vite": "^4.2.2",
+        "lucide-vue-next": "^1.0.0",
         "nuxt": "^4.4.2",
         "pinia": "^3.0.4",
         "tailwindcss": "^4.2.2"
@@ -6746,6 +6747,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/magic-regexp": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@pinia/nuxt": "^0.11.3",
     "@tailwindcss/vite": "^4.2.2",
+    "lucide-vue-next": "^1.0.0",
     "nuxt": "^4.4.2",
     "pinia": "^3.0.4",
     "tailwindcss": "^4.2.2"


### PR DESCRIPTION
## Resumo

Design system completo do Memorai com dark/light mode.

## Mudanças

- Design tokens via `@theme` no Tailwind CSS 4
  - Primary: roxo (#7C3AED, escala 400-900)
  - Accent IA: cyan (#06B6D4, escala 400-600)
  - Semânticas: success, danger, warning, info
- CSS variables para dark/light mode (bg, text, border)
- Custom utilities: `bg-surface`, `text-base-primary`, `border-base`, etc.
- Dark mode via classe `.dark` (toggle manual, não media query)
- Composable `useColorMode` (toggle, set, init, persistência localStorage)
- Fonte Inter via Google Fonts (400, 500, 600)
- Lucide Icons (`lucide-vue-next`) instalado
- Dark mode como default

## Decisões

- Accent IA em cyan (não roxo) para contraste real com primary
- CSS variables para tokens dinâmicos, `@theme` para estáticos
- ADR-008 documenta todas as decisões