### PR TITLE
feat(user): implementar layout, navegação e auth frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .output
 dist
 .env
+.idea/

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <NuxtLayout>
     <NuxtPage />
-  </div>
+  </NuxtLayout>
 </template>
 
 <script setup lang="ts">

--- a/app/components/ui/BottomNav.vue
+++ b/app/components/ui/BottomNav.vue
@@ -1,0 +1,53 @@
+<template>
+  <nav
+    class="lg:hidden fixed bottom-0 left-0 right-0 bg-surface-secondary border-t border-base z-50"
+    aria-label="Navegação mobile"
+  >
+    <div class="flex items-center justify-around h-16">
+      <NuxtLink
+        v-for="item in items"
+        :key="item.to"
+        :to="item.to"
+        class="flex flex-col items-center gap-0.5 px-3 py-1.5 text-micro transition-all duration-150"
+        :class="isActive(item.to) ? 'text-primary-400' : 'text-base-muted'"
+        :aria-current="isActive(item.to) ? 'page' : undefined"
+      >
+        <component :is="getIcon(item.icon)" :size="22" :stroke-width="1.5" />
+        {{ item.label }}
+      </NuxtLink>
+    </div>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import {
+  LayoutDashboard,
+  Layers,
+  BookOpen,
+  BarChart3,
+} from 'lucide-vue-next'
+
+const route = useRoute()
+
+const items = [
+  { label: 'Dashboard', to: '/dashboard', icon: 'dashboard' },
+  { label: 'Decks', to: '/decks', icon: 'decks' },
+  { label: 'Revisão', to: '/review', icon: 'review' },
+  { label: 'Stats', to: '/stats', icon: 'stats' },
+]
+
+const iconMap: Record<string, any> = {
+  dashboard: LayoutDashboard,
+  decks: Layers,
+  review: BookOpen,
+  stats: BarChart3,
+}
+
+function getIcon(name: string) {
+  return iconMap[name]
+}
+
+function isActive(path: string) {
+  return route.path === path || route.path.startsWith(path + '/')
+}
+</script>

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -1,0 +1,65 @@
+<template>
+  <aside class="hidden lg:flex flex-col bg-surface-secondary h-screen fixed left-0 top-0 w-[220px] p-4">
+    <NuxtLink to="/dashboard" class="text-display text-primary-400 mb-8">
+      Memorai
+    </NuxtLink>
+
+    <nav class="flex flex-col gap-1 flex-1" aria-label="Navegação principal">
+      <NuxtLink
+        v-for="item in items"
+        :key="item.to"
+        :to="item.to"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-small text-base-secondary transition-all duration-150"
+        :class="isActive(item.to) ? 'bg-primary-500/10 text-primary-400 font-medium' : 'hover:bg-surface-tertiary'"
+        :aria-current="isActive(item.to) ? 'page' : undefined"
+      >
+        <component :is="getIcon(item.icon)" :size="20" :stroke-width="1.5" />
+        {{ item.label }}
+      </NuxtLink>
+    </nav>
+
+    <div class="border-t border-base pt-4 mt-4">
+      <NuxtLink
+        to="/settings"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-small text-base-muted hover:bg-surface-tertiary transition-all duration-150"
+      >
+        <Settings :size="20" :stroke-width="1.5" />
+        Configurações
+      </NuxtLink>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import {
+  LayoutDashboard,
+  Layers,
+  BookOpen,
+  BarChart3,
+  Settings,
+} from 'lucide-vue-next'
+
+const route = useRoute()
+
+const items = [
+  { label: 'Dashboard', to: '/dashboard', icon: 'dashboard' },
+  { label: 'Decks', to: '/decks', icon: 'decks' },
+  { label: 'Revisão', to: '/review', icon: 'review' },
+  { label: 'Estatísticas', to: '/stats', icon: 'stats' },
+]
+
+const iconMap: Record<string, any> = {
+  dashboard: LayoutDashboard,
+  decks: Layers,
+  review: BookOpen,
+  stats: BarChart3,
+}
+
+function getIcon(name: string) {
+  return iconMap[name]
+}
+
+function isActive(path: string) {
+  return route.path === path || route.path.startsWith(path + '/')
+}
+</script>

--- a/app/components/ui/Toast.vue
+++ b/app/components/ui/Toast.vue
@@ -1,0 +1,44 @@
+<template>
+  <Teleport to="body">
+    <Transition name="toast">
+      <div
+        v-if="visible"
+        role="alert"
+        class="fixed top-4 right-4 z-[100] max-w-sm px-4 py-3 rounded-xl text-small font-medium shadow-lg"
+        :class="typeClasses"
+      >
+        {{ message }}
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  message: string
+  type?: 'success' | 'error' | 'warning' | 'info'
+  visible: boolean
+}>()
+
+const typeClasses = computed(() => {
+  const map: Record<string, string> = {
+    success: 'bg-success/15 text-success',
+    error: 'bg-danger/15 text-danger',
+    warning: 'bg-warning/15 text-warning',
+    info: 'bg-info/15 text-info',
+  }
+  return map[props.type ?? 'success']
+})
+</script>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 200ms ease-in-out;
+}
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+</style>

--- a/app/composables/useToast.ts
+++ b/app/composables/useToast.ts
@@ -1,0 +1,25 @@
+interface ToastState {
+  message: string
+  type: 'success' | 'error' | 'warning' | 'info'
+  visible: boolean
+}
+
+const state = reactive<ToastState>({
+  message: '',
+  type: 'success',
+  visible: false,
+})
+
+let timeout: ReturnType<typeof setTimeout>
+
+export function useToast() {
+  function show(message: string, type: ToastState['type'] = 'success', duration = 3000) {
+    clearTimeout(timeout)
+    state.message = message
+    state.type = type
+    state.visible = true
+    timeout = setTimeout(() => { state.visible = false }, duration)
+  }
+
+  return { state, show }
+}

--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="min-h-screen bg-surface flex items-center justify-center">
+    <div class="w-full max-w-md px-4">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="min-h-screen bg-surface">
+    <UiSidebar />
+    <UiBottomNav />
+
+    <main class="lg:ml-[220px] pb-20 lg:pb-0">
+      <slot />
+    </main>
+
+    <UiToast
+      :message="toast.state.message"
+      :type="toast.state.type"
+      :visible="toast.state.visible"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const toast = useToast()
+</script>

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -1,0 +1,8 @@
+export default defineNuxtRouteMiddleware((to) => {
+  const auth = useAuthStore()
+  auth.loadFromCookie()
+
+  if (!auth.isAuthenticated && to.path !== '/login' && to.path !== '/register') {
+    return navigateTo('/login')
+  }
+})

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-display text-base-primary">Dashboard</h1>
+    <p class="text-base-secondary mt-2">Em breve.</p>
+  </div>
+</template>

--- a/app/pages/decks/index.vue
+++ b/app/pages/decks/index.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-display text-base-primary">Seus decks</h1>
+    <p class="text-base-secondary mt-2">Em breve.</p>
+  </div>
+</template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,5 +1,3 @@
-<template>
-  <div class="flex min-h-screen items-center justify-center">
-    <h1 class="text-4xl font-bold">Memorai</h1>
-  </div>
-</template>
+<script setup lang="ts">
+navigateTo('/dashboard')
+</script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <h1 class="text-display text-primary-400 text-center mb-2">Memorai</h1>
+    <p class="text-base-muted text-center mb-8">Faça login para continuar</p>
+
+    <form @submit.prevent="handleLogin" class="flex flex-col gap-4">
+      <div>
+        <label for="email" class="text-label mb-1 block">E-mail</label>
+        <input
+          id="email"
+          v-model="form.email"
+          type="email"
+          placeholder="seu@email.com"
+          class="input-base"
+          :aria-invalid="!!errors.email"
+          :aria-describedby="errors.email ? 'email-error' : undefined"
+        />
+        <p v-if="errors.email" id="email-error" role="alert" class="text-danger text-micro mt-1">{{ errors.email }}</p>
+      </div>
+
+      <div>
+        <label for="password" class="text-label mb-1 block">Senha</label>
+        <input
+          id="password"
+          v-model="form.password"
+          type="password"
+          placeholder="••••••••"
+          class="input-base"
+          :aria-invalid="!!errors.password"
+          :aria-describedby="errors.password ? 'password-error' : undefined"
+        />
+        <p v-if="errors.password" id="password-error" role="alert" class="text-danger text-micro mt-1">{{ errors.password }}</p>
+      </div>
+
+      <button type="submit" class="btn-primary w-full mt-2" :disabled="loading">
+        {{ loading ? 'Entrando...' : 'Entrar' }}
+      </button>
+
+      <p v-if="errors.general" role="alert" class="text-danger text-small text-center">{{ errors.general }}</p>
+    </form>
+
+    <p class="text-base-muted text-small text-center mt-6">
+      Não tem conta?
+      <NuxtLink to="/register" class="text-primary-400 hover:underline">Criar conta</NuxtLink>
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: 'auth' })
+
+const { $api } = useNuxtApp()
+const auth = useAuthStore()
+
+const form = reactive({ email: '', password: '' })
+const errors = reactive<Record<string, string>>({})
+const loading = ref(false)
+
+async function handleLogin() {
+  Object.keys(errors).forEach(k => delete errors[k])
+  loading.value = true
+
+  try {
+    const res = await $api<any>('/login', {
+      method: 'POST',
+      body: { ...form, device_name: 'web' },
+    })
+    auth.setAuth(res.data.user, res.data.token)
+    await navigateTo('/dashboard')
+  } catch (e: any) {
+    const data = e.data
+    if (data?.errors) {
+      Object.entries(data.errors).forEach(([k, v]: any) => { errors[k] = v[0] })
+    } else {
+      errors.general = data?.message || 'Erro ao fazer login.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,0 +1,111 @@
+<template>
+  <div>
+    <h1 class="text-display text-primary-400 text-center mb-2">Memorai</h1>
+    <p class="text-base-muted text-center mb-8">Crie sua conta gratuita</p>
+
+    <form @submit.prevent="handleRegister" class="flex flex-col gap-4">
+      <div>
+        <label for="name" class="text-label mb-1 block">Nome</label>
+        <input
+          id="name"
+          v-model="form.name"
+          type="text"
+          placeholder="Seu nome"
+          class="input-base"
+          :aria-invalid="!!errors.name"
+          :aria-describedby="errors.name ? 'name-error' : undefined"
+        />
+        <p v-if="errors.name" id="name-error" role="alert" class="text-danger text-micro mt-1">{{ errors.name }}</p>
+      </div>
+
+      <div>
+        <label for="email" class="text-label mb-1 block">E-mail</label>
+        <input
+          id="email"
+          v-model="form.email"
+          type="email"
+          placeholder="seu@email.com"
+          class="input-base"
+          :aria-invalid="!!errors.email"
+          :aria-describedby="errors.email ? 'email-error' : undefined"
+        />
+        <p v-if="errors.email" id="email-error" role="alert" class="text-danger text-micro mt-1">{{ errors.email }}</p>
+      </div>
+
+      <div>
+        <label for="password" class="text-label mb-1 block">Senha</label>
+        <input
+          id="password"
+          v-model="form.password"
+          type="password"
+          placeholder="Mínimo 8 caracteres"
+          class="input-base"
+          :aria-invalid="!!errors.password"
+          :aria-describedby="errors.password ? 'password-error' : undefined"
+        />
+        <p v-if="errors.password" id="password-error" role="alert" class="text-danger text-micro mt-1">{{ errors.password }}</p>
+      </div>
+
+      <div>
+        <label for="password_confirmation" class="text-label mb-1 block">Confirmar senha</label>
+        <input
+          id="password_confirmation"
+          v-model="form.password_confirmation"
+          type="password"
+          placeholder="Repita a senha"
+          class="input-base"
+        />
+      </div>
+
+      <button type="submit" class="btn-primary w-full mt-2" :disabled="loading">
+        {{ loading ? 'Criando...' : 'Criar conta' }}
+      </button>
+
+      <p v-if="errors.general" role="alert" class="text-danger text-small text-center">{{ errors.general }}</p>
+    </form>
+
+    <p class="text-base-muted text-small text-center mt-6">
+      Já tem conta?
+      <NuxtLink to="/login" class="text-primary-400 hover:underline">Entrar</NuxtLink>
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: 'auth' })
+
+const { $api } = useNuxtApp()
+const auth = useAuthStore()
+
+const form = reactive({
+  name: '',
+  email: '',
+  password: '',
+  password_confirmation: '',
+})
+const errors = reactive<Record<string, string>>({})
+const loading = ref(false)
+
+async function handleRegister() {
+  Object.keys(errors).forEach(k => delete errors[k])
+  loading.value = true
+
+  try {
+    const res = await $api<any>('/register', {
+      method: 'POST',
+      body: { ...form, device_name: 'web' },
+    })
+    auth.setAuth(res.data.user, res.data.token)
+    await navigateTo('/dashboard')
+  } catch (e: any) {
+    const data = e.data
+    if (data?.errors) {
+      Object.entries(data.errors).forEach(([k, v]: any) => { errors[k] = v[0] })
+    } else {
+      errors.general = data?.message || 'Erro ao criar conta.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-display text-base-primary">Revisão</h1>
+    <p class="text-base-secondary mt-2">Em breve.</p>
+  </div>
+</template>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-display text-base-primary">Configurações</h1>
+    <p class="text-base-secondary mt-2">Em breve.</p>
+  </div>
+</template>

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-display text-base-primary">Estatísticas</h1>
+    <p class="text-base-secondary mt-2">Em breve.</p>
+  </div>
+</template>

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import type { User } from '~/types'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    user: null as User | null,
+    token: null as string | null,
+  }),
+
+  getters: {
+    isAuthenticated: (state) => !!state.token,
+  },
+
+  actions: {
+    setAuth(user: User, token: string) {
+      this.user = user
+      this.token = token
+      const cookie = useCookie('auth_token', { maxAge: 60 * 60 * 24 * 30 })
+      cookie.value = token
+    },
+
+    clearAuth() {
+      this.user = null
+      this.token = null
+      const cookie = useCookie('auth_token')
+      cookie.value = null
+    },
+
+    loadFromCookie() {
+      const cookie = useCookie('auth_token')
+      if (cookie.value) {
+        this.token = cookie.value
+      }
+    },
+  },
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -9,3 +9,47 @@ export interface ApiResponse<T> {
   data: T
   message?: string
 }
+
+export interface Deck {
+  id: string
+  name: string
+  description: string | null
+  cards_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface Flashcard {
+  id: string
+  deck_id: string
+  type: string
+  front: string
+  back: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ReviewPayload {
+  flashcard_id: string
+  rating: 1 | 2 | 3 | 4
+}
+
+export interface Stats {
+  total_cards: number
+  total_decks: number
+  due_today: number
+  reviewed_today: number
+  streak: number
+  ratings_today: {
+    again: number
+    hard: number
+    good: number
+    easy: number
+  }
+}
+
+export interface NavItem {
+  label: string
+  to: string
+  icon: string
+}


### PR DESCRIPTION
## Resumo

Layout, navegação e auth frontend (Tarefas 6 e 7 da Fase 1).

## Mudanças

### Layout
- `default.vue`: sidebar desktop + bottom nav mobile + toast global
- `auth.vue`: centralizado, limpo, sem navegação

### Navegação
- `Sidebar.vue`: 4 itens + settings, Lucide icons, item ativo em roxo
- `BottomNav.vue`: 4 itens mobile, fixo no bottom

### Auth
- `auth.ts` store: token em cookie, setAuth/clearAuth
- `auth.global.ts` middleware: redireciona pra /login
- `login.vue`: formulário com validação e erros da API
- `register.vue`: formulário completo com confirmação de senha

### Componentes
- `Toast.vue` + `useToast` composable

### Acessibilidade
- Labels em todos os inputs
- `aria-invalid`, `aria-describedby` para erros
- `role="alert"` em mensagens de erro
- `aria-current="page"` no item ativo da nav
- `aria-label` nas navs