### PR TITLE
feat(flashcard): implementar páginas de decks e flashcards

### DIFF
--- a/app/components/flashcard/DeckCard.vue
+++ b/app/components/flashcard/DeckCard.vue
@@ -1,0 +1,16 @@
+<template>
+  <NuxtLink :to="`/decks/${deck.id}`" class="card-interactive">
+    <div class="flex items-center justify-between mb-2">
+      <p class="text-title">{{ deck.name }}</p>
+      <span v-if="deck.cards_count" class="badge badge-success">{{ deck.cards_count }} cards</span>
+      <span v-else class="badge badge-muted">Vazio</span>
+    </div>
+    <p v-if="deck.description" class="text-base-muted text-small line-clamp-2">{{ deck.description }}</p>
+  </NuxtLink>
+</template>
+
+<script setup lang="ts">
+import type { Deck } from '~/types'
+
+defineProps<{ deck: Deck }>()
+</script>

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="p-6 max-w-5xl mx-auto">
+    <!-- Loading -->
+    <div v-if="deckStore.loading && !deckStore.current" class="space-y-4">
+      <div class="skeleton h-8 w-64" />
+      <div class="skeleton h-4 w-48" />
+      <div class="grid grid-cols-3 gap-4 mt-6">
+        <div v-for="i in 3" :key="i" class="card"><div class="skeleton h-6 w-20" /></div>
+      </div>
+    </div>
+
+    <template v-else-if="deckStore.current">
+      <!-- Header -->
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <NuxtLink to="/decks" class="text-small text-base-muted hover:text-primary-400 mb-2 inline-block">← Voltar</NuxtLink>
+          <h1 class="text-display">{{ deckStore.current.name }}</h1>
+          <p v-if="deckStore.current.description" class="text-base-secondary mt-1">{{ deckStore.current.description }}</p>
+        </div>
+        <div class="flex gap-3">
+          <NuxtLink to="/review" class="btn-primary">
+            <Play :size="18" /> Revisar este deck
+          </NuxtLink>
+          <button class="btn-secondary" @click="showAdd = true">
+            <Plus :size="18" /> Adicionar card
+          </button>
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-8">
+        <div class="card text-center">
+          <p class="text-label">Total cards</p>
+          <p class="text-2xl font-bold text-base-primary mt-1">{{ deckStore.current.cards_count ?? 0 }}</p>
+        </div>
+        <div class="card text-center">
+          <p class="text-label">Criado em</p>
+          <p class="text-small text-base-primary mt-1">{{ formatDate(deckStore.current.created_at) }}</p>
+        </div>
+      </div>
+
+      <!-- Add card modal -->
+      <div v-if="showAdd" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showAdd = false">
+        <div class="card w-full max-w-lg mx-4 p-6" role="dialog" aria-label="Adicionar flashcard">
+          <h2 class="text-headline mb-4">Novo card</h2>
+          <form @submit.prevent="handleAddCard" class="flex flex-col gap-4">
+            <div>
+              <label for="card-front" class="text-label mb-1 block">Frente</label>
+              <textarea id="card-front" v-model="cardForm.front" class="textarea-base" rows="3" placeholder="Digite a pergunta..." />
+            </div>
+            <div>
+              <label for="card-back" class="text-label mb-1 block">Verso</label>
+              <textarea id="card-back" v-model="cardForm.back" class="textarea-base" rows="3" placeholder="Digite a resposta..." />
+            </div>
+            <div class="flex gap-3 justify-end">
+              <button type="button" class="btn-secondary" @click="showAdd = false">Cancelar</button>
+              <button type="submit" class="btn-primary" :disabled="!cardForm.front || !cardForm.back || adding">
+                {{ adding ? 'Salvando...' : 'Salvar' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <!-- Cards list -->
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-headline">Conteúdo do Deck</h2>
+      </div>
+
+      <div v-if="flashcardStore.loading" class="space-y-3">
+        <div v-for="i in 3" :key="i" class="card">
+          <div class="skeleton h-4 w-3/4 mb-2" />
+          <div class="skeleton h-3 w-1/2" />
+        </div>
+      </div>
+
+      <div v-else-if="flashcardStore.flashcards.length" class="space-y-3">
+        <div v-for="card in flashcardStore.flashcards" :key="card.id" class="card group">
+          <p class="text-base-primary font-medium">{{ card.front }}</p>
+          <div class="bg-surface-tertiary rounded-lg p-3 mt-2">
+            <p class="text-base-secondary text-small italic">"{{ card.back }}"</p>
+          </div>
+          <div class="flex justify-end gap-2 mt-3 opacity-0 group-hover:opacity-100 transition-opacity">
+            <button class="text-micro text-danger hover:underline" @click="handleDelete(card.id)">Remover</button>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="card text-center py-10">
+        <p class="text-base-secondary">Nenhum card neste deck.</p>
+        <button class="btn-primary mt-4" @click="showAdd = true">Adicionar primeiro card</button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Play, Plus } from 'lucide-vue-next'
+
+const route = useRoute()
+const deckStore = useDeckStore()
+const flashcardStore = useFlashcardStore()
+const toast = useToast()
+
+const deckId = route.params.id as string
+const showAdd = ref(false)
+const adding = ref(false)
+const cardForm = reactive({ front: '', back: '' })
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+async function handleAddCard() {
+  adding.value = true
+  try {
+    await flashcardStore.create(deckId, { front: cardForm.front, back: cardForm.back })
+    toast.show('Card criado!', 'success')
+    showAdd.value = false
+    cardForm.front = ''
+    cardForm.back = ''
+    await deckStore.fetchDeck(deckId)
+  } catch {
+    toast.show('Erro ao criar card.', 'error')
+  } finally {
+    adding.value = false
+  }
+}
+
+async function handleDelete(cardId: string) {
+  try {
+    await flashcardStore.remove(cardId)
+    toast.show('Card removido.', 'success')
+    await deckStore.fetchDeck(deckId)
+  } catch {
+    toast.show('Erro ao remover card.', 'error')
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([
+    deckStore.fetchDeck(deckId),
+    flashcardStore.fetchForDeck(deckId),
+  ])
+})
+</script>

--- a/app/pages/decks/index.vue
+++ b/app/pages/decks/index.vue
@@ -1,6 +1,81 @@
 <template>
-  <div class="p-6">
-    <h1 class="text-display text-base-primary">Seus decks</h1>
-    <p class="text-base-secondary mt-2">Em breve.</p>
+  <div class="p-6 max-w-5xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-display">Seus decks</h1>
+      <button class="btn-primary" @click="showCreate = true">
+        <Plus :size="18" /> Novo deck
+      </button>
+    </div>
+
+    <!-- Create modal -->
+    <div v-if="showCreate" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showCreate = false">
+      <div class="card w-full max-w-md mx-4 p-6" role="dialog" aria-label="Criar deck">
+        <h2 class="text-headline mb-4">Novo deck</h2>
+        <form @submit.prevent="handleCreate" class="flex flex-col gap-4">
+          <div>
+            <label for="deck-name" class="text-label mb-1 block">Nome</label>
+            <input id="deck-name" v-model="form.name" class="input-base" placeholder="Ex: Direito Constitucional" />
+          </div>
+          <div>
+            <label for="deck-desc" class="text-label mb-1 block">Descrição (opcional)</label>
+            <input id="deck-desc" v-model="form.description" class="input-base" placeholder="Ex: Artigos 5º ao 37" />
+          </div>
+          <div class="flex gap-3 justify-end">
+            <button type="button" class="btn-secondary" @click="showCreate = false">Cancelar</button>
+            <button type="submit" class="btn-primary" :disabled="!form.name || creating">
+              {{ creating ? 'Criando...' : 'Criar' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="deckStore.loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-for="i in 6" :key="i" class="card">
+        <div class="skeleton h-5 w-40 mb-3" />
+        <div class="skeleton h-3 w-56" />
+      </div>
+    </div>
+
+    <!-- Decks grid -->
+    <div v-else-if="deckStore.decks.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <FlashcardDeckCard v-for="deck in deckStore.decks" :key="deck.id" :deck="deck" />
+    </div>
+
+    <!-- Empty -->
+    <div v-else class="card text-center py-16">
+      <p class="text-base-secondary text-title">Nenhum deck ainda</p>
+      <p class="text-base-muted text-small mt-1">Crie seu primeiro deck para começar a estudar.</p>
+      <button class="btn-primary mt-6" @click="showCreate = true">Criar primeiro deck</button>
+    </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { Plus } from 'lucide-vue-next'
+
+const deckStore = useDeckStore()
+const toast = useToast()
+
+const showCreate = ref(false)
+const creating = ref(false)
+const form = reactive({ name: '', description: '' })
+
+async function handleCreate() {
+  creating.value = true
+  try {
+    await deckStore.createDeck({ name: form.name, description: form.description || undefined })
+    toast.show('Deck criado!', 'success')
+    showCreate.value = false
+    form.name = ''
+    form.description = ''
+  } catch {
+    toast.show('Erro ao criar deck.', 'error')
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(() => deckStore.fetchDecks())
+</script>

--- a/app/stores/deck.ts
+++ b/app/stores/deck.ts
@@ -4,6 +4,7 @@ import type { Deck } from '~/types'
 export const useDeckStore = defineStore('deck', {
   state: () => ({
     decks: [] as Deck[],
+    current: null as Deck | null,
     loading: false,
   }),
 
@@ -17,6 +18,40 @@ export const useDeckStore = defineStore('deck', {
       } finally {
         this.loading = false
       }
+    },
+
+    async fetchDeck(id: string) {
+      this.loading = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>(`/decks/${id}`)
+        this.current = res.data
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async createDeck(data: { name: string; description?: string }) {
+      const { $api } = useNuxtApp()
+      const res = await $api<any>('/decks', { method: 'POST', body: data })
+      this.decks.unshift(res.data)
+      return res.data
+    },
+
+    async updateDeck(id: string, data: { name?: string; description?: string }) {
+      const { $api } = useNuxtApp()
+      const res = await $api<any>(`/decks/${id}`, { method: 'PUT', body: data })
+      const idx = this.decks.findIndex(d => d.id === id)
+      if (idx !== -1) this.decks[idx] = res.data
+      if (this.current?.id === id) this.current = res.data
+      return res.data
+    },
+
+    async deleteDeck(id: string) {
+      const { $api } = useNuxtApp()
+      await $api(`/decks/${id}`, { method: 'DELETE' })
+      this.decks = this.decks.filter(d => d.id !== id)
+      if (this.current?.id === id) this.current = null
     },
   },
 })

--- a/app/stores/flashcard.ts
+++ b/app/stores/flashcard.ts
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import type { Flashcard } from '~/types'
+
+export const useFlashcardStore = defineStore('flashcard', {
+  state: () => ({
+    flashcards: [] as Flashcard[],
+    loading: false,
+  }),
+
+  actions: {
+    async fetchForDeck(deckId: string) {
+      this.loading = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>(`/decks/${deckId}/flashcards`)
+        this.flashcards = res.data
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async create(deckId: string, data: { front: string; back: string }) {
+      const { $api } = useNuxtApp()
+      const res = await $api<any>(`/decks/${deckId}/flashcards`, { method: 'POST', body: data })
+      this.flashcards.unshift(res.data)
+      return res.data
+    },
+
+    async update(id: string, data: { front?: string; back?: string }) {
+      const { $api } = useNuxtApp()
+      const res = await $api<any>(`/flashcards/${id}`, { method: 'PUT', body: data })
+      const idx = this.flashcards.findIndex(f => f.id === id)
+      if (idx !== -1) this.flashcards[idx] = res.data
+      return res.data
+    },
+
+    async remove(id: string) {
+      const { $api } = useNuxtApp()
+      await $api(`/flashcards/${id}`, { method: 'DELETE' })
+      this.flashcards = this.flashcards.filter(f => f.id !== id)
+    },
+  },
+})

--- a/tests/stores/flashcard.test.ts
+++ b/tests/stores/flashcard.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useFlashcardStore } from '~/stores/flashcard'
+
+describe('useFlashcardStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts with empty flashcards', () => {
+    const store = useFlashcardStore()
+    expect(store.flashcards).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Resumo

Páginas de Decks e Flashcards (Tarefas 9 e 10).

## Mudanças

- `decks/index.vue`: listagem grid, modal criação, skeleton, estado vazio
- `decks/[id].vue`: detalhe do deck, lista de cards com frente/verso, modal adicionar card, remover card com hover
- `DeckCard.vue`: card interativo com badge de contagem
- Deck store expandido: `createDeck`, `updateDeck`, `deleteDeck`, `fetchDeck`
- Flashcard store: `fetchForDeck`, `create`, `update`, `remove`
- Teste do flashcard store