### PR TITLE
feat(flashcard): FSRS-6 + learning steps + configurações do deck (#22)

### DIFF
--- a/app/components/deck/Settings.vue
+++ b/app/components/deck/Settings.vue
@@ -1,82 +1,103 @@
 <template>
-  <div class="card p-5 space-y-5">
-    <h3 class="text-headline flex items-center gap-2">
-      <Settings :size="18" /> Configurações de Estudo
-    </h3>
-
-    <!-- Learning steps -->
-    <div>
-      <label for="learning-steps" class="text-label mb-1 block">Passos de aprendizado</label>
-      <input
-        id="learning-steps"
-        v-model="learningInput"
-        type="text"
-        class="input-base w-full"
-        placeholder="1m 10m"
-        aria-describedby="learning-help"
-      />
-      <p id="learning-help" class="text-micro text-base-muted mt-1">
-        Quando você vê um card pela primeira vez e erra, ele aparece de novo após esses intervalos antes de ser agendado pro dia seguinte. Ex: <strong>1m 10m</strong> = aparece em 1 minuto, depois em 10 minutos. Deixe vazio para o FSRS calcular automaticamente.
-      </p>
-    </div>
-
-    <!-- Relearning steps -->
-    <div>
-      <label for="relearning-steps" class="text-label mb-1 block">Passos de reaprendizado</label>
-      <input
-        id="relearning-steps"
-        v-model="relearningInput"
-        type="text"
-        class="input-base w-full"
-        placeholder="10m"
-        aria-describedby="relearning-help"
-      />
-      <p id="relearning-help" class="text-micro text-base-muted mt-1">
-        Quando você erra um card que já conhecia, ele passa por esses intervalos antes de voltar pra fila normal. Ex: <strong>10m</strong> = reaparece em 10 minutos.
-      </p>
-    </div>
-
-    <!-- Desired retention -->
-    <div>
-      <label for="retention" class="text-label mb-1 block">
-        Retenção desejada: <strong class="text-primary-400">{{ Math.round(retention * 100) }}%</strong>
-      </label>
-      <input
-        id="retention"
-        v-model.number="retention"
-        type="range"
-        min="0.70"
-        max="0.97"
-        step="0.01"
-        class="w-full accent-primary-500"
-        aria-describedby="retention-help"
-      />
-      <div class="flex justify-between text-micro text-base-muted">
-        <span>70%</span>
-        <span>97%</span>
+  <div class="card overflow-hidden">
+    <!-- Header (always visible) -->
+    <button
+      class="w-full flex items-center justify-between p-5 text-left hover:bg-surface-secondary/50 transition-colors"
+      :aria-expanded="open"
+      aria-controls="deck-settings-panel"
+      @click="open = !open"
+    >
+      <div class="flex items-center gap-2">
+        <Settings :size="18" class="text-base-muted" />
+        <span class="text-label">Configurações de Estudo</span>
       </div>
-      <p id="retention-help" class="text-micro text-base-muted mt-1">
-        Probabilidade de lembrar o card na próxima revisão. <strong>90% é o padrão.</strong> Mais alto = mais revisões, menos esquecimento. Mais baixo = menos revisões, mais esquecimento.
-      </p>
-    </div>
+      <div class="flex items-center gap-3">
+        <span v-if="!open" class="text-micro text-base-muted hidden sm:inline">
+          {{ Math.round(retention * 100) }}% retenção · passos: {{ learningInput || 'nenhum' }} · reaprendizado: {{ relearningInput || 'nenhum' }}
+        </span>
+        <ChevronDown :size="16" class="text-base-muted transition-transform" :class="{ 'rotate-180': open }" />
+      </div>
+    </button>
 
-    <!-- Save -->
-    <div class="flex justify-end">
-      <button class="btn-primary" :disabled="saving" @click="save">
-        {{ saving ? 'Salvando...' : 'Salvar configurações' }}
-      </button>
-    </div>
+    <!-- Panel (collapsible) -->
+    <Transition name="collapse">
+      <div v-if="open" id="deck-settings-panel" class="px-5 pb-5 space-y-5 border-t border-base">
+        <!-- Learning steps -->
+        <div class="pt-4">
+          <label for="learning-steps" class="text-label mb-1 block">Passos de aprendizado</label>
+          <input
+            id="learning-steps"
+            v-model="learningInput"
+            type="text"
+            class="input-base w-full"
+            placeholder="1m 10m"
+            aria-describedby="learning-help"
+          />
+          <p id="learning-help" class="text-micro text-base-muted mt-1">
+            Quando você vê um card pela primeira vez e erra, ele aparece de novo após esses intervalos antes de ser agendado pro dia seguinte. Ex: <strong>1m 10m</strong> = aparece em 1 minuto, depois em 10 minutos. Deixe vazio para o FSRS calcular automaticamente.
+          </p>
+        </div>
+
+        <!-- Relearning steps -->
+        <div>
+          <label for="relearning-steps" class="text-label mb-1 block">Passos de reaprendizado</label>
+          <input
+            id="relearning-steps"
+            v-model="relearningInput"
+            type="text"
+            class="input-base w-full"
+            placeholder="10m"
+            aria-describedby="relearning-help"
+          />
+          <p id="relearning-help" class="text-micro text-base-muted mt-1">
+            Quando você erra um card que já conhecia, ele passa por esses intervalos antes de voltar pra fila normal. Ex: <strong>10m</strong> = reaparece em 10 minutos.
+          </p>
+        </div>
+
+        <!-- Desired retention -->
+        <div>
+          <label for="retention" class="text-label mb-1 block">
+            Retenção desejada: <strong class="text-primary-400">{{ Math.round(retention * 100) }}%</strong>
+          </label>
+          <input
+            id="retention"
+            v-model.number="retention"
+            type="range"
+            min="0.70"
+            max="0.97"
+            step="0.01"
+            class="w-full accent-primary-500"
+            aria-describedby="retention-help"
+          />
+          <div class="flex justify-between text-micro text-base-muted">
+            <span>70%</span>
+            <span>97%</span>
+          </div>
+          <p id="retention-help" class="text-micro text-base-muted mt-1">
+            Probabilidade de lembrar o card na próxima revisão. <strong>90% é o padrão.</strong> Mais alto = mais revisões, menos esquecimento. Mais baixo = menos revisões, mais esquecimento.
+          </p>
+        </div>
+
+        <!-- Save -->
+        <div class="flex justify-end">
+          <button class="btn-primary" :disabled="saving" @click="save">
+            {{ saving ? 'Salvando...' : 'Salvar' }}
+          </button>
+        </div>
+      </div>
+    </Transition>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Settings } from 'lucide-vue-next'
+import { Settings, ChevronDown } from 'lucide-vue-next'
 import type { Deck } from '~/types'
 
 const props = defineProps<{ deck: Deck }>()
 const toast = useToast()
 const deckStore = useDeckStore()
 const saving = ref(false)
+const open = ref(false)
 
 const learningInput = ref(formatSteps(props.deck.learning_steps))
 const relearningInput = ref(formatSteps(props.deck.relearning_steps))
@@ -117,3 +138,23 @@ watch(() => props.deck, (d) => {
   retention.value = d.desired_retention ?? 0.9
 })
 </script>
+
+<style scoped>
+.collapse-enter-active,
+.collapse-leave-active {
+  transition: all 200ms ease-in-out;
+  overflow: hidden;
+}
+.collapse-enter-from,
+.collapse-leave-to {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.collapse-enter-to,
+.collapse-leave-from {
+  opacity: 1;
+  max-height: 600px;
+}
+</style>

--- a/app/components/deck/Settings.vue
+++ b/app/components/deck/Settings.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="card p-5 space-y-5">
+    <h3 class="text-headline flex items-center gap-2">
+      <Settings :size="18" /> Configurações de Estudo
+    </h3>
+
+    <!-- Learning steps -->
+    <div>
+      <label for="learning-steps" class="text-label mb-1 block">Passos de aprendizado</label>
+      <input
+        id="learning-steps"
+        v-model="learningInput"
+        type="text"
+        class="input-base w-full"
+        placeholder="1m 10m"
+        aria-describedby="learning-help"
+      />
+      <p id="learning-help" class="text-micro text-base-muted mt-1">
+        Quando você vê um card pela primeira vez e erra, ele aparece de novo após esses intervalos antes de ser agendado pro dia seguinte. Ex: <strong>1m 10m</strong> = aparece em 1 minuto, depois em 10 minutos. Deixe vazio para o FSRS calcular automaticamente.
+      </p>
+    </div>
+
+    <!-- Relearning steps -->
+    <div>
+      <label for="relearning-steps" class="text-label mb-1 block">Passos de reaprendizado</label>
+      <input
+        id="relearning-steps"
+        v-model="relearningInput"
+        type="text"
+        class="input-base w-full"
+        placeholder="10m"
+        aria-describedby="relearning-help"
+      />
+      <p id="relearning-help" class="text-micro text-base-muted mt-1">
+        Quando você erra um card que já conhecia, ele passa por esses intervalos antes de voltar pra fila normal. Ex: <strong>10m</strong> = reaparece em 10 minutos.
+      </p>
+    </div>
+
+    <!-- Desired retention -->
+    <div>
+      <label for="retention" class="text-label mb-1 block">
+        Retenção desejada: <strong class="text-primary-400">{{ Math.round(retention * 100) }}%</strong>
+      </label>
+      <input
+        id="retention"
+        v-model.number="retention"
+        type="range"
+        min="0.70"
+        max="0.97"
+        step="0.01"
+        class="w-full accent-primary-500"
+        aria-describedby="retention-help"
+      />
+      <div class="flex justify-between text-micro text-base-muted">
+        <span>70%</span>
+        <span>97%</span>
+      </div>
+      <p id="retention-help" class="text-micro text-base-muted mt-1">
+        Probabilidade de lembrar o card na próxima revisão. <strong>90% é o padrão.</strong> Mais alto = mais revisões, menos esquecimento. Mais baixo = menos revisões, mais esquecimento.
+      </p>
+    </div>
+
+    <!-- Save -->
+    <div class="flex justify-end">
+      <button class="btn-primary" :disabled="saving" @click="save">
+        {{ saving ? 'Salvando...' : 'Salvar configurações' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Settings } from 'lucide-vue-next'
+import type { Deck } from '~/types'
+
+const props = defineProps<{ deck: Deck }>()
+const toast = useToast()
+const deckStore = useDeckStore()
+const saving = ref(false)
+
+const learningInput = ref(formatSteps(props.deck.learning_steps))
+const relearningInput = ref(formatSteps(props.deck.relearning_steps))
+const retention = ref(props.deck.desired_retention ?? 0.9)
+
+function formatSteps(steps: number[]): string {
+  return steps.map(s => `${s}m`).join(' ')
+}
+
+function parseSteps(input: string): number[] {
+  if (!input.trim()) return []
+  return input
+    .trim()
+    .split(/[\s,]+/)
+    .map(s => parseInt(s.replace(/m$/i, ''), 10))
+    .filter(n => !isNaN(n) && n >= 1 && n <= 1439)
+}
+
+async function save() {
+  saving.value = true
+  try {
+    await deckStore.updateSettings(props.deck.id, {
+      learning_steps: parseSteps(learningInput.value),
+      relearning_steps: parseSteps(relearningInput.value),
+      desired_retention: retention.value,
+    })
+    toast.show('Configurações salvas!', 'success')
+  } catch {
+    toast.show('Erro ao salvar configurações.', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(() => props.deck, (d) => {
+  learningInput.value = formatSteps(d.learning_steps)
+  relearningInput.value = formatSteps(d.relearning_steps)
+  retention.value = d.desired_retention ?? 0.9
+})
+</script>

--- a/app/components/flashcard/Buttons.vue
+++ b/app/components/flashcard/Buttons.vue
@@ -1,31 +1,31 @@
 <template>
   <div class="grid grid-cols-4 gap-3 w-full max-w-lg mx-auto">
-    <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="labels[0]">
+    <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="`Errei — ${intervals.again}`">
       <RotateCcw :size="20" />
       <span class="flex flex-col items-center">
         <span>Errei</span>
-        <span v-if="intervals[0]" class="text-micro opacity-75">{{ intervals[0] }}</span>
+        <span class="text-micro opacity-75">{{ intervals.again }}</span>
       </span>
     </button>
-    <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="labels[1]">
+    <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="`Difícil — ${intervals.hard}`">
       <Frown :size="20" />
       <span class="flex flex-col items-center">
         <span>Difícil</span>
-        <span v-if="intervals[1]" class="text-micro opacity-75">{{ intervals[1] }}</span>
+        <span class="text-micro opacity-75">{{ intervals.hard }}</span>
       </span>
     </button>
-    <button class="btn-good" :disabled="disabled" @click="onRate(3)" :aria-label="labels[2]">
+    <button class="btn-good" :disabled="disabled" @click="onRate(3)" :aria-label="`Bom — ${intervals.good}`">
       <CheckCircle :size="20" />
       <span class="flex flex-col items-center">
         <span>Bom</span>
-        <span v-if="intervals[2]" class="text-micro opacity-75">{{ intervals[2] }}</span>
+        <span class="text-micro opacity-75">{{ intervals.good }}</span>
       </span>
     </button>
-    <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="labels[3]">
+    <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="`Fácil — ${intervals.easy}`">
       <Sparkles :size="20" />
       <span class="flex flex-col items-center">
         <span>Fácil</span>
-        <span v-if="intervals[3]" class="text-micro opacity-75">{{ intervals[3] }}</span>
+        <span class="text-micro opacity-75">{{ intervals.easy }}</span>
       </span>
     </button>
   </div>
@@ -33,13 +33,10 @@
 
 <script setup lang="ts">
 import { RotateCcw, Frown, CheckCircle, Sparkles } from 'lucide-vue-next'
-import type { Flashcard } from '~/types'
 
 const props = defineProps<{
   disabled?: boolean
-  card?: Flashcard | null
-  learningSteps?: number[]
-  relearningSteps?: number[]
+  intervals: { again: string; hard: string; good: string; easy: string }
 }>()
 
 const emit = defineEmits<{ (e: 'rate', rating: number): void }>()
@@ -47,37 +44,4 @@ const emit = defineEmits<{ (e: 'rate', rating: number): void }>()
 function onRate(rating: number) {
   emit('rate', rating)
 }
-
-function formatMinutes(m: number): string {
-  if (m < 60) return `${m}min`
-  return `${Math.round(m / 60)}h`
-}
-
-const isLearning = computed(() => props.card?.is_learning ?? false)
-
-const intervals = computed(() => {
-  if (!isLearning.value || !props.card) return ['', '', '', '']
-
-  const steps = props.card.state === 'relearning'
-    ? (props.relearningSteps ?? [10])
-    : (props.learningSteps ?? [1, 10])
-
-  const idx = props.card.learning_step_index ?? 0
-
-  // Again: step[0], Hard: step[current], Good: step[next] or graduate, Easy: graduate
-  const again = steps.length ? formatMinutes(steps[0]) : ''
-  const hard = steps.length ? formatMinutes(steps[idx] ?? steps[0]) : ''
-  const nextIdx = idx + 1
-  const good = nextIdx < steps.length ? formatMinutes(steps[nextIdx]) : ''
-  const easy = '' // Easy always graduates
-
-  return [again, hard, good, easy]
-})
-
-const labels = computed(() => [
-  `Errei${intervals.value[0] ? ` — ${intervals.value[0]}` : ''}`,
-  `Difícil${intervals.value[1] ? ` — ${intervals.value[1]}` : ''}`,
-  `Bom${intervals.value[2] ? ` — ${intervals.value[2]}` : ''}`,
-  `Fácil — pular aprendizado`,
-])
 </script>

--- a/app/components/flashcard/Buttons.vue
+++ b/app/components/flashcard/Buttons.vue
@@ -1,31 +1,83 @@
 <template>
   <div class="grid grid-cols-4 gap-3 w-full max-w-lg mx-auto">
-    <button class="btn-again" :disabled="disabled" @click="onRate(1)" aria-label="Errei — revisar em breve">
+    <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="labels[0]">
       <RotateCcw :size="20" />
-      Errei
+      <span class="flex flex-col items-center">
+        <span>Errei</span>
+        <span v-if="intervals[0]" class="text-micro opacity-75">{{ intervals[0] }}</span>
+      </span>
     </button>
-    <button class="btn-hard" :disabled="disabled" @click="onRate(2)" aria-label="Difícil — revisar em pouco tempo">
+    <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="labels[1]">
       <Frown :size="20" />
-      Difícil
+      <span class="flex flex-col items-center">
+        <span>Difícil</span>
+        <span v-if="intervals[1]" class="text-micro opacity-75">{{ intervals[1] }}</span>
+      </span>
     </button>
-    <button class="btn-good" :disabled="disabled" @click="onRate(3)" aria-label="Bom — revisar normalmente">
+    <button class="btn-good" :disabled="disabled" @click="onRate(3)" :aria-label="labels[2]">
       <CheckCircle :size="20" />
-      Bom
+      <span class="flex flex-col items-center">
+        <span>Bom</span>
+        <span v-if="intervals[2]" class="text-micro opacity-75">{{ intervals[2] }}</span>
+      </span>
     </button>
-    <button class="btn-easy" :disabled="disabled" @click="onRate(4)" aria-label="Fácil — revisar mais tarde">
+    <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="labels[3]">
       <Sparkles :size="20" />
-      Fácil
+      <span class="flex flex-col items-center">
+        <span>Fácil</span>
+        <span v-if="intervals[3]" class="text-micro opacity-75">{{ intervals[3] }}</span>
+      </span>
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { RotateCcw, Frown, CheckCircle, Sparkles } from 'lucide-vue-next'
+import type { Flashcard } from '~/types'
 
-defineProps<{ disabled?: boolean }>()
+const props = defineProps<{
+  disabled?: boolean
+  card?: Flashcard | null
+  learningSteps?: number[]
+  relearningSteps?: number[]
+}>()
+
 const emit = defineEmits<{ (e: 'rate', rating: number): void }>()
 
 function onRate(rating: number) {
   emit('rate', rating)
 }
+
+function formatMinutes(m: number): string {
+  if (m < 60) return `${m}min`
+  return `${Math.round(m / 60)}h`
+}
+
+const isLearning = computed(() => props.card?.is_learning ?? false)
+
+const intervals = computed(() => {
+  if (!isLearning.value || !props.card) return ['', '', '', '']
+
+  const steps = props.card.state === 'relearning'
+    ? (props.relearningSteps ?? [10])
+    : (props.learningSteps ?? [1, 10])
+
+  const idx = props.card.learning_step_index ?? 0
+
+  // Again: step[0], Hard: step[current], Good: step[next] or graduate, Easy: graduate
+  const again = steps.length ? formatMinutes(steps[0]) : ''
+  const hard = steps.length ? formatMinutes(steps[idx] ?? steps[0]) : ''
+  const nextIdx = idx + 1
+  const good = nextIdx < steps.length ? formatMinutes(steps[nextIdx]) : ''
+  const easy = '' // Easy always graduates
+
+  return [again, hard, good, easy]
+})
+
+const labels = computed(() => [
+  `Errei${intervals.value[0] ? ` — ${intervals.value[0]}` : ''}`,
+  `Difícil${intervals.value[1] ? ` — ${intervals.value[1]}` : ''}`,
+  `Bom${intervals.value[2] ? ` — ${intervals.value[2]}` : ''}`,
+  `Fácil — pular aprendizado`,
+])
 </script>

--- a/app/components/flashcard/CreateModal.vue
+++ b/app/components/flashcard/CreateModal.vue
@@ -1,0 +1,50 @@
+<template>
+  <UiModal v-model="open" size="md" aria-label="Adicionar flashcard">
+    <h2 class="text-headline mb-4">Novo card</h2>
+    <form @submit.prevent="submit" class="flex flex-col gap-4">
+      <div>
+        <label for="card-front" class="text-label mb-1 block">Frente</label>
+        <textarea id="card-front" v-model="form.front" class="textarea-base" rows="3" placeholder="Digite a pergunta..." />
+      </div>
+      <div>
+        <label for="card-back" class="text-label mb-1 block">Verso</label>
+        <textarea id="card-back" v-model="form.back" class="textarea-base" rows="3" placeholder="Digite a resposta..." />
+      </div>
+      <div class="flex gap-3 justify-end">
+        <button type="button" class="btn-secondary" @click="open = false">Cancelar</button>
+        <button type="submit" class="btn-primary" :disabled="!form.front || !form.back || saving">
+          {{ saving ? 'Salvando...' : 'Salvar' }}
+        </button>
+      </div>
+    </form>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ deckId: string }>()
+const emit = defineEmits<{ (e: 'created'): void }>()
+const open = defineModel<boolean>({ required: true })
+
+const flashcardStore = useFlashcardStore()
+const deckStore = useDeckStore()
+const toast = useToast()
+const saving = ref(false)
+const form = reactive({ front: '', back: '' })
+
+async function submit() {
+  saving.value = true
+  try {
+    await flashcardStore.create(props.deckId, { front: form.front, back: form.back })
+    toast.show('Card criado!', 'success')
+    open.value = false
+    form.front = ''
+    form.back = ''
+    await deckStore.fetchDeck(props.deckId)
+    emit('created')
+  } catch {
+    toast.show('Erro ao criar card.', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/app/components/ui/ConfirmModal.vue
+++ b/app/components/ui/ConfirmModal.vue
@@ -1,0 +1,38 @@
+<template>
+  <UiModal v-model="open" size="sm" role="alertdialog" :aria-label="title">
+    <h2 class="text-headline mb-2">{{ title }}</h2>
+    <p class="text-base-secondary text-small mb-6">{{ message }}</p>
+    <div class="flex gap-3 justify-end">
+      <button class="btn-secondary" @click="open = false">{{ cancelLabel }}</button>
+      <button
+        :class="variant === 'primary' ? 'btn-primary' : 'btn-danger'"
+        :disabled="loading"
+        @click="$emit('confirm')"
+      >
+        {{ loading ? loadingLabel : confirmLabel }}
+      </button>
+    </div>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  loadingLabel?: string
+  loading?: boolean
+  variant?: 'danger' | 'primary'
+}>(), {
+  confirmLabel: 'Confirmar',
+  cancelLabel: 'Cancelar',
+  loadingLabel: 'Aguarde...',
+  loading: false,
+  variant: 'danger',
+})
+
+defineEmits<{ (e: 'confirm'): void }>()
+
+const open = defineModel<boolean>({ required: true })
+</script>

--- a/app/components/ui/Modal.vue
+++ b/app/components/ui/Modal.vue
@@ -1,0 +1,57 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        @click.self="close"
+        @keydown.escape="close"
+      >
+        <div
+          class="card w-full mx-4 p-6"
+          :class="sizeClass"
+          :role="role"
+          :aria-label="ariaLabel"
+        >
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  modelValue: boolean
+  size?: 'sm' | 'md' | 'lg'
+  role?: string
+  ariaLabel?: string
+}>(), {
+  size: 'md',
+  role: 'dialog',
+  ariaLabel: undefined,
+})
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>()
+
+const sizeClass = computed(() => ({
+  sm: 'max-w-sm',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+}[props.size]))
+
+function close() {
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 150ms ease;
+}
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+</style>

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -62,6 +62,9 @@
         </div>
       </div>
 
+      <!-- Study settings -->
+      <DeckSettings :deck="deckStore.current" class="mb-8" />
+
       <!-- Cards list -->
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-headline">Conteúdo do Deck</h2>

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -39,40 +39,15 @@
         </div>
       </div>
 
-      <!-- Add card modal -->
-      <div v-if="showAdd" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showAdd = false">
-        <div class="card w-full max-w-lg mx-4 p-6" role="dialog" aria-label="Adicionar flashcard">
-          <h2 class="text-headline mb-4">Novo card</h2>
-          <form @submit.prevent="handleAddCard" class="flex flex-col gap-4">
-            <div>
-              <label for="card-front" class="text-label mb-1 block">Frente</label>
-              <textarea id="card-front" v-model="cardForm.front" class="textarea-base" rows="3" placeholder="Digite a pergunta..." />
-            </div>
-            <div>
-              <label for="card-back" class="text-label mb-1 block">Verso</label>
-              <textarea id="card-back" v-model="cardForm.back" class="textarea-base" rows="3" placeholder="Digite a resposta..." />
-            </div>
-            <div class="flex gap-3 justify-end">
-              <button type="button" class="btn-secondary" @click="showAdd = false">Cancelar</button>
-              <button type="submit" class="btn-primary" :disabled="!cardForm.front || !cardForm.back || adding">
-                {{ adding ? 'Salvando...' : 'Salvar' }}
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-
-      <!-- Delete confirmation modal -->
-      <div v-if="deleteTarget" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="deleteTarget = null">
-        <div class="card w-full max-w-sm mx-4 p-6" role="alertdialog" aria-label="Confirmar remoção">
-          <h2 class="text-headline mb-2">Remover card?</h2>
-          <p class="text-base-secondary text-small mb-6">Essa ação não pode ser desfeita.</p>
-          <div class="flex gap-3 justify-end">
-            <button class="btn-secondary" @click="deleteTarget = null">Cancelar</button>
-            <button class="btn-danger" @click="handleDelete">Remover</button>
-          </div>
-        </div>
-      </div>
+      <!-- Modals -->
+      <FlashcardCreateModal v-model="showAdd" :deck-id="deckId" />
+      <UiConfirmModal
+        v-model="showDelete"
+        title="Remover card?"
+        message="Essa ação não pode ser desfeita."
+        confirm-label="Remover"
+        @confirm="handleDelete"
+      />
 
       <!-- Study settings -->
       <DeckSettings :deck="deckStore.current" class="mb-8" />
@@ -126,41 +101,21 @@ const toast = useToast()
 
 const deckId = route.params.id as string
 const showAdd = ref(false)
-const adding = ref(false)
-const cardForm = reactive({ front: '', back: '' })
-const expandedCards = ref(new Set<string>())
+const showDelete = ref(false)
 const deleteTarget = ref<string | null>(null)
+const expandedCards = ref(new Set<string>())
 
 function toggleCard(id: string) {
-  if (expandedCards.value.has(id)) {
-    expandedCards.value.delete(id)
-  } else {
-    expandedCards.value.add(id)
-  }
+  expandedCards.value.has(id) ? expandedCards.value.delete(id) : expandedCards.value.add(id)
 }
 
 function formatDate(date: string) {
   return new Date(date).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
-async function handleAddCard() {
-  adding.value = true
-  try {
-    await flashcardStore.create(deckId, { front: cardForm.front, back: cardForm.back })
-    toast.show('Card criado!', 'success')
-    showAdd.value = false
-    cardForm.front = ''
-    cardForm.back = ''
-    await deckStore.fetchDeck(deckId)
-  } catch {
-    toast.show('Erro ao criar card.', 'error')
-  } finally {
-    adding.value = false
-  }
-}
-
 function confirmDelete(cardId: string) {
   deleteTarget.value = cardId
+  showDelete.value = true
 }
 
 async function handleDelete() {
@@ -172,6 +127,7 @@ async function handleDelete() {
   } catch {
     toast.show('Erro ao remover card.', 'error')
   } finally {
+    showDelete.value = false
     deleteTarget.value = null
   }
 }

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -62,6 +62,18 @@
         </div>
       </div>
 
+      <!-- Delete confirmation modal -->
+      <div v-if="deleteTarget" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="deleteTarget = null">
+        <div class="card w-full max-w-sm mx-4 p-6" role="alertdialog" aria-label="Confirmar remoção">
+          <h2 class="text-headline mb-2">Remover card?</h2>
+          <p class="text-base-secondary text-small mb-6">Essa ação não pode ser desfeita.</p>
+          <div class="flex gap-3 justify-end">
+            <button class="btn-secondary" @click="deleteTarget = null">Cancelar</button>
+            <button class="btn-danger" @click="handleDelete">Remover</button>
+          </div>
+        </div>
+      </div>
+
       <!-- Study settings -->
       <DeckSettings :deck="deckStore.current" class="mb-8" />
 
@@ -85,7 +97,7 @@
               <button class="text-micro text-primary-400 hover:underline" @click="toggleCard(card.id)">
                 {{ expandedCards.has(card.id) ? 'Ocultar' : 'Ver verso' }}
               </button>
-              <button class="text-micro text-danger" @click="handleDelete(card.id)">Remover</button>
+              <button class="text-micro text-danger" @click="confirmDelete(card.id)">Remover</button>
             </div>
           </div>
           <Transition name="expand">
@@ -117,6 +129,7 @@ const showAdd = ref(false)
 const adding = ref(false)
 const cardForm = reactive({ front: '', back: '' })
 const expandedCards = ref(new Set<string>())
+const deleteTarget = ref<string | null>(null)
 
 function toggleCard(id: string) {
   if (expandedCards.value.has(id)) {
@@ -146,13 +159,20 @@ async function handleAddCard() {
   }
 }
 
-async function handleDelete(cardId: string) {
+function confirmDelete(cardId: string) {
+  deleteTarget.value = cardId
+}
+
+async function handleDelete() {
+  if (!deleteTarget.value) return
   try {
-    await flashcardStore.remove(cardId)
+    await flashcardStore.remove(deleteTarget.value)
     toast.show('Card removido.', 'success')
     await deckStore.fetchDeck(deckId)
   } catch {
     toast.show('Erro ao remover card.', 'error')
+  } finally {
+    deleteTarget.value = null
   }
 }
 

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -32,8 +32,28 @@
       </div>
     </div>
 
+    <!-- Waiting for learning cards -->
+    <div v-else-if="!review.currentCard && review.pendingLearning > 0" class="flex-1 flex flex-col items-center justify-center px-4 text-center">
+      <p class="text-2xl mb-4">⏳</p>
+      <h2 class="text-title">Aguardando cards em aprendizado</h2>
+      <p class="text-base-secondary mt-2">
+        {{ review.pendingLearning }} card{{ review.pendingLearning !== 1 ? 's' : '' }} voltando em breve...
+      </p>
+      <p class="text-base-muted text-small mt-1">Próximo em {{ nextLearningIn }}</p>
+    </div>
+
     <!-- Review -->
     <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 gap-8">
+      <!-- Learning badge -->
+      <div v-if="review.currentCard.is_learning" class="flex items-center gap-2">
+        <span
+          class="px-3 py-1 rounded-full text-micro font-medium"
+          :class="review.currentCard.state === 'relearning' ? 'bg-orange-500/20 text-orange-400' : 'bg-blue-500/20 text-blue-400'"
+        >
+          {{ review.currentCard.state === 'relearning' ? '🔄 Reaprendendo' : '📖 Aprendendo' }}
+        </span>
+      </div>
+
       <FlashcardCard
         :card="review.currentCard"
         :flipped="review.flipped"
@@ -43,6 +63,9 @@
       <FlashcardButtons
         v-if="review.flipped"
         :disabled="review.submitting"
+        :card="review.currentCard"
+        :learning-steps="currentDeckSettings.learningSteps"
+        :relearning-steps="currentDeckSettings.relearningSteps"
         @rate="handleRate"
       />
     </div>
@@ -58,25 +81,58 @@
 
 <script setup lang="ts">
 const review = useReviewStore()
+const deckStore = useDeckStore()
 const route = useRoute()
 const toast = useToast()
 
+const currentDeckSettings = computed(() => ({
+  learningSteps: deckStore.current?.learning_steps ?? [1, 10],
+  relearningSteps: deckStore.current?.relearning_steps ?? [10],
+}))
+
+// Timer for learning cards
+const nextLearningIn = ref('')
+let timerInterval: ReturnType<typeof setInterval> | null = null
+
+function updateTimer() {
+  if (!review.pendingLearning) {
+    nextLearningIn.value = ''
+    return
+  }
+  const now = Date.now()
+  const nearest = Math.min(...review.learningQueue.map(q => q.dueAt))
+  const diff = Math.max(0, nearest - now)
+  const secs = Math.ceil(diff / 1000)
+  if (secs <= 0) {
+    // Force reactivity — a learning card is due
+    nextLearningIn.value = 'agora!'
+    return
+  }
+  const m = Math.floor(secs / 60)
+  const s = secs % 60
+  nextLearningIn.value = m > 0 ? `${m}min ${s}s` : `${s}s`
+}
+
 async function handleRate(rating: number) {
-  console.log('handleRate called:', rating)
   try {
     await review.submitReview(rating as 1 | 2 | 3 | 4)
-    console.log('submitReview done, finished:', review.finished)
     if (review.finished) {
       toast.show('Sessão concluída! 🎉', 'success')
     }
-  } catch (e: any) {
-    console.error('Review error:', e)
+  } catch {
     toast.show('Erro ao enviar revisão.', 'error')
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   const deckId = route.query.deck_id as string | undefined
-  review.fetchSession(deckId)
+  if (deckId) await deckStore.fetchDeck(deckId)
+  await review.fetchSession(deckId)
+
+  timerInterval = setInterval(updateTimer, 1000)
+})
+
+onUnmounted(() => {
+  if (timerInterval) clearInterval(timerInterval)
 })
 </script>

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -29,10 +29,7 @@
       <p v-if="review.pendingLearning > 0" class="text-base-muted text-small mt-2">
         {{ review.pendingLearning }} card{{ review.pendingLearning !== 1 ? 's' : '' }} em aprendizado — {{ review.pendingLearning === 1 ? 'volta' : 'voltam' }} em breve.
       </p>
-      <div class="flex gap-3 mt-8">
-        <NuxtLink to="/dashboard" class="btn-secondary">Voltar ao dashboard</NuxtLink>
-        <button class="btn-primary" @click="review.fetchSession(deckId)">Nova sessão</button>
-      </div>
+      <NuxtLink to="/dashboard" class="btn-primary mt-8">Voltar ao dashboard</NuxtLink>
     </div>
 
     <!-- Review -->

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -63,9 +63,7 @@
       <FlashcardButtons
         v-if="review.flipped"
         :disabled="review.submitting"
-        :card="review.currentCard"
-        :learning-steps="currentDeckSettings.learningSteps"
-        :relearning-steps="currentDeckSettings.relearningSteps"
+        :intervals="review.currentIntervals"
         @rate="handleRate"
       />
     </div>
@@ -84,11 +82,6 @@ const review = useReviewStore()
 const deckStore = useDeckStore()
 const route = useRoute()
 const toast = useToast()
-
-const currentDeckSettings = computed(() => ({
-  learningSteps: deckStore.current?.learning_steps ?? [1, 10],
-  relearningSteps: deckStore.current?.relearning_steps ?? [10],
-}))
 
 // Timer for learning cards
 const nextLearningIn = ref('')

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -19,27 +19,20 @@
       <div class="skeleton h-64 w-full max-w-lg rounded-2xl" />
     </div>
 
-    <!-- Finished -->
-    <div v-else-if="review.finished" class="flex-1 flex flex-col items-center justify-center px-4 text-center">
+    <!-- Finished (or waiting for learning cards) -->
+    <div v-else-if="review.finished || (!review.currentCard && review.pendingLearning > 0)" class="flex-1 flex flex-col items-center justify-center px-4 text-center">
       <p class="text-4xl mb-4">🎉</p>
       <h2 class="text-display">Sessão concluída!</h2>
       <p class="text-base-secondary mt-2">
-        Você revisou {{ review.total }} card{{ review.total !== 1 ? 's' : '' }}.
+        Você revisou {{ review.reviewed }} card{{ review.reviewed !== 1 ? 's' : '' }}.
+      </p>
+      <p v-if="review.pendingLearning > 0" class="text-base-muted text-small mt-2">
+        {{ review.pendingLearning }} card{{ review.pendingLearning !== 1 ? 's' : '' }} em aprendizado — {{ review.pendingLearning === 1 ? 'volta' : 'voltam' }} em breve.
       </p>
       <div class="flex gap-3 mt-8">
         <NuxtLink to="/dashboard" class="btn-secondary">Voltar ao dashboard</NuxtLink>
-        <button class="btn-primary" @click="review.fetchSession()">Nova sessão</button>
+        <button class="btn-primary" @click="review.fetchSession(deckId)">Nova sessão</button>
       </div>
-    </div>
-
-    <!-- Waiting for learning cards -->
-    <div v-else-if="!review.currentCard && review.pendingLearning > 0" class="flex-1 flex flex-col items-center justify-center px-4 text-center">
-      <p class="text-2xl mb-4">⏳</p>
-      <h2 class="text-title">Aguardando cards em aprendizado</h2>
-      <p class="text-base-secondary mt-2">
-        {{ review.pendingLearning }} card{{ review.pendingLearning !== 1 ? 's' : '' }} voltando em breve...
-      </p>
-      <p class="text-base-muted text-small mt-1">Próximo em {{ nextLearningIn }}</p>
     </div>
 
     <!-- Review -->
@@ -82,34 +75,12 @@ const review = useReviewStore()
 const deckStore = useDeckStore()
 const route = useRoute()
 const toast = useToast()
-
-// Timer for learning cards
-const nextLearningIn = ref('')
-let timerInterval: ReturnType<typeof setInterval> | null = null
-
-function updateTimer() {
-  if (!review.pendingLearning) {
-    nextLearningIn.value = ''
-    return
-  }
-  const now = Date.now()
-  const nearest = Math.min(...review.learningQueue.map(q => q.dueAt))
-  const diff = Math.max(0, nearest - now)
-  const secs = Math.ceil(diff / 1000)
-  if (secs <= 0) {
-    // Force reactivity — a learning card is due
-    nextLearningIn.value = 'agora!'
-    return
-  }
-  const m = Math.floor(secs / 60)
-  const s = secs % 60
-  nextLearningIn.value = m > 0 ? `${m}min ${s}s` : `${s}s`
-}
+const deckId = route.query.deck_id as string | undefined
 
 async function handleRate(rating: number) {
   try {
     await review.submitReview(rating as 1 | 2 | 3 | 4)
-    if (review.finished) {
+    if (review.finished || (!review.currentCard && review.pendingLearning > 0)) {
       toast.show('Sessão concluída! 🎉', 'success')
     }
   } catch {
@@ -118,14 +89,7 @@ async function handleRate(rating: number) {
 }
 
 onMounted(async () => {
-  const deckId = route.query.deck_id as string | undefined
   if (deckId) await deckStore.fetchDeck(deckId)
   await review.fetchSession(deckId)
-
-  timerInterval = setInterval(updateTimer, 1000)
-})
-
-onUnmounted(() => {
-  if (timerInterval) clearInterval(timerInterval)
 })
 </script>

--- a/app/pages/stats.vue
+++ b/app/pages/stats.vue
@@ -35,7 +35,7 @@
       <h2 class="text-headline mb-4">Revisões de hoje</h2>
       <div class="card mb-10">
         <div class="flex items-center justify-between mb-4">
-          <p class="text-base-secondary">{{ stats.reviewed_today }} cards revisados</p>
+          <p class="text-base-secondary">{{ stats.reviewed_today }} revisões · {{ stats.cards_reviewed_today }} cards</p>
         </div>
 
         <!-- Rating bars -->

--- a/app/stores/deck.ts
+++ b/app/stores/deck.ts
@@ -53,5 +53,14 @@ export const useDeckStore = defineStore('deck', {
       this.decks = this.decks.filter(d => d.id !== id)
       if (this.current?.id === id) this.current = null
     },
+
+    async updateSettings(id: string, data: { learning_steps?: number[]; relearning_steps?: number[]; desired_retention?: number }) {
+      const { $api } = useNuxtApp()
+      const res = await $api<any>(`/decks/${id}/settings`, { method: 'PUT', body: data })
+      if (this.current?.id === id) this.current = res.data
+      const idx = this.decks.findIndex(d => d.id === id)
+      if (idx !== -1) this.decks[idx] = res.data
+      return res.data
+    },
   },
 })

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -77,15 +77,22 @@ export const useReviewStore = defineStore('review', {
         // Remove from learning queue if it was there
         this.learningQueue = this.learningQueue.filter(q => q.card.id !== card.id)
 
-        if (updatedCard.is_learning && updatedCard.due) {
-          const dueAt = new Date(updatedCard.due).getTime()
-          this.learningQueue.push({ card: updatedCard, dueAt })
-        }
-
         // Advance main queue index if card was from it
         const wasFromMainQueue = this.cards.some(c => c.id === card.id)
         if (wasFromMainQueue) {
           this.currentIndex++
+        }
+
+        const hasMoreMainCards = this.currentIndex < this.cards.length
+
+        if (updatedCard.is_learning) {
+          if (!hasMoreMainCards && this.learningQueue.length === 0) {
+            // No other cards waiting — show learning card again immediately (learn ahead)
+            this.learningQueue.push({ card: updatedCard, dueAt: Date.now() })
+          } else if (updatedCard.due) {
+            // Other cards in queue — respect the timer
+            this.learningQueue.push({ card: updatedCard, dueAt: new Date(updatedCard.due).getTime() })
+          }
         }
 
         this.flipped = false

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -26,12 +26,11 @@ export const useReviewStore = defineStore('review', {
     currentIntervals(): { again: string; hard: string; good: string; easy: string } {
       return this.currentCard?.next_intervals ?? { again: '', hard: '', good: '', easy: '' }
     },
-    total: (state) => state.cards.length + state.learningQueue.length,
+    total: (state) => state.cards.length,
     reviewed: (state) => state.currentIndex,
     progress(state): number {
-      const total = state.cards.length + state.learningQueue.length
-      if (!total) return 0
-      return Math.round((state.currentIndex / total) * 100)
+      if (!state.cards.length) return 0
+      return Math.round((state.currentIndex / state.cards.length) * 100)
     },
     pendingLearning: (state) => state.learningQueue.length,
   },

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -4,6 +4,7 @@ import type { Flashcard, ReviewPayload } from '~/types'
 export const useReviewStore = defineStore('review', {
   state: () => ({
     cards: [] as Flashcard[],
+    learningQueue: [] as { card: Flashcard; dueAt: number }[],
     currentIndex: 0,
     flipped: false,
     loading: false,
@@ -12,10 +13,22 @@ export const useReviewStore = defineStore('review', {
   }),
 
   getters: {
-    currentCard: (state) => state.cards[state.currentIndex] ?? null,
-    total: (state) => state.cards.length,
+    currentCard(state): Flashcard | null {
+      // Check if any learning card is due
+      const now = Date.now()
+      const dueLearn = state.learningQueue.find(q => q.dueAt <= now)
+      if (dueLearn) return dueLearn.card
+
+      return state.cards[state.currentIndex] ?? null
+    },
+    total: (state) => state.cards.length + state.learningQueue.length,
     reviewed: (state) => state.currentIndex,
-    progress: (state) => state.cards.length ? Math.round((state.currentIndex / state.cards.length) * 100) : 0,
+    progress(state): number {
+      const total = state.cards.length + state.learningQueue.length
+      if (!total) return 0
+      return Math.round((state.currentIndex / total) * 100)
+    },
+    pendingLearning: (state) => state.learningQueue.length,
   },
 
   actions: {
@@ -24,6 +37,7 @@ export const useReviewStore = defineStore('review', {
       this.finished = false
       this.currentIndex = 0
       this.flipped = false
+      this.learningQueue = []
       try {
         const { $api } = useNuxtApp()
         const query = deckId ? `?deck_id=${deckId}` : ''
@@ -40,21 +54,56 @@ export const useReviewStore = defineStore('review', {
     },
 
     async submitReview(rating: 1 | 2 | 3 | 4) {
-      if (!this.currentCard || this.submitting) return
+      const card = this.currentCard
+      if (!card || this.submitting) return
       this.submitting = true
       try {
         const { $api } = useNuxtApp()
-        await $api('/review', {
+        const res = await $api<any>('/review', {
           method: 'POST',
-          body: { flashcard_id: this.currentCard.id, rating } as ReviewPayload,
+          body: { flashcard_id: card.id, rating } as ReviewPayload,
         })
-        this.flipped = false
-        this.currentIndex++
-        if (this.currentIndex >= this.cards.length) {
-          this.finished = true
+
+        const updatedCard = res.data.flashcard as Flashcard
+
+        // Remove from learning queue if it was there
+        this.learningQueue = this.learningQueue.filter(q => q.card.id !== card.id)
+
+        // If card is still in learning, add to learning queue with timer
+        if (updatedCard.is_learning && updatedCard.due) {
+          const dueAt = new Date(updatedCard.due).getTime()
+          this.learningQueue.push({ card: updatedCard, dueAt })
         }
+
+        // Only advance index if the card was from the main queue
+        if (!card.is_learning || !this.cards.some(c => c.id === card.id)) {
+          // Card was from learning queue, don't advance
+        } else {
+          this.currentIndex++
+        }
+
+        // Advance if current card was from main queue
+        if (this.cards[this.currentIndex - 1]?.id === card.id || (!card.is_learning && this.cards[this.currentIndex]?.id !== card.id)) {
+          // Already advanced or was learning card
+        }
+
+        this.flipped = false
+        this.checkFinished()
       } finally {
         this.submitting = false
+      }
+    },
+
+    checkFinished() {
+      const now = Date.now()
+      const hasMainCards = this.currentIndex < this.cards.length
+      const hasDueLearning = this.learningQueue.some(q => q.dueAt <= now)
+      const hasPendingLearning = this.learningQueue.length > 0
+
+      if (!hasMainCards && !hasPendingLearning) {
+        this.finished = true
+      } else if (!hasMainCards && hasPendingLearning && !hasDueLearning) {
+        // All main cards done, waiting for learning cards — don't mark finished
       }
     },
   },

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -1,10 +1,14 @@
 import { defineStore } from 'pinia'
-import type { Flashcard, ReviewPayload } from '~/types'
+import type { Flashcard } from '~/types'
+
+interface SessionCard extends Flashcard {
+  next_intervals: { again: string; hard: string; good: string; easy: string }
+}
 
 export const useReviewStore = defineStore('review', {
   state: () => ({
-    cards: [] as Flashcard[],
-    learningQueue: [] as { card: Flashcard; dueAt: number }[],
+    cards: [] as SessionCard[],
+    learningQueue: [] as { card: SessionCard; dueAt: number }[],
     currentIndex: 0,
     flipped: false,
     loading: false,
@@ -13,13 +17,14 @@ export const useReviewStore = defineStore('review', {
   }),
 
   getters: {
-    currentCard(state): Flashcard | null {
-      // Check if any learning card is due
+    currentCard(state): SessionCard | null {
       const now = Date.now()
       const dueLearn = state.learningQueue.find(q => q.dueAt <= now)
       if (dueLearn) return dueLearn.card
-
       return state.cards[state.currentIndex] ?? null
+    },
+    currentIntervals(): { again: string; hard: string; good: string; easy: string } {
+      return this.currentCard?.next_intervals ?? { again: '', hard: '', good: '', easy: '' }
     },
     total: (state) => state.cards.length + state.learningQueue.length,
     reviewed: (state) => state.currentIndex,
@@ -61,30 +66,26 @@ export const useReviewStore = defineStore('review', {
         const { $api } = useNuxtApp()
         const res = await $api<any>('/review', {
           method: 'POST',
-          body: { flashcard_id: card.id, rating } as ReviewPayload,
+          body: { flashcard_id: card.id, rating },
         })
 
-        const updatedCard = res.data.flashcard as Flashcard
+        const updatedCard = {
+          ...res.data.flashcard,
+          next_intervals: res.data.next_intervals,
+        } as SessionCard
 
         // Remove from learning queue if it was there
         this.learningQueue = this.learningQueue.filter(q => q.card.id !== card.id)
 
-        // If card is still in learning, add to learning queue with timer
         if (updatedCard.is_learning && updatedCard.due) {
           const dueAt = new Date(updatedCard.due).getTime()
           this.learningQueue.push({ card: updatedCard, dueAt })
         }
 
-        // Only advance index if the card was from the main queue
-        if (!card.is_learning || !this.cards.some(c => c.id === card.id)) {
-          // Card was from learning queue, don't advance
-        } else {
+        // Advance main queue index if card was from it
+        const wasFromMainQueue = this.cards.some(c => c.id === card.id)
+        if (wasFromMainQueue) {
           this.currentIndex++
-        }
-
-        // Advance if current card was from main queue
-        if (this.cards[this.currentIndex - 1]?.id === card.id || (!card.is_learning && this.cards[this.currentIndex]?.id !== card.id)) {
-          // Already advanced or was learning card
         }
 
         this.flipped = false
@@ -95,15 +96,10 @@ export const useReviewStore = defineStore('review', {
     },
 
     checkFinished() {
-      const now = Date.now()
       const hasMainCards = this.currentIndex < this.cards.length
-      const hasDueLearning = this.learningQueue.some(q => q.dueAt <= now)
       const hasPendingLearning = this.learningQueue.length > 0
-
       if (!hasMainCards && !hasPendingLearning) {
         this.finished = true
-      } else if (!hasMainCards && hasPendingLearning && !hasDueLearning) {
-        // All main cards done, waiting for learning cards — don't mark finished
       }
     },
   },

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -15,6 +15,9 @@ export interface Deck {
   name: string
   description: string | null
   cards_count: number
+  learning_steps: number[]
+  relearning_steps: number[]
+  desired_retention: number
   created_at: string
   updated_at: string
 }
@@ -25,6 +28,14 @@ export interface Flashcard {
   type: string
   front: string
   back: string
+  state: string
+  due: string | null
+  stability: number
+  difficulty: number
+  reps: number
+  lapses: number
+  learning_step_index: number | null
+  is_learning: boolean
   created_at: string
   updated_at: string
 }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -50,6 +50,7 @@ export interface Stats {
   total_decks: number
   due_today: number
   reviewed_today: number
+  cards_reviewed_today: number
   streak: number
   ratings_today: {
     again: number


### PR DESCRIPTION
## Resumo

Frontend completo para FSRS-6, learning steps, configurações do deck e melhorias de UX.

Relacionado: we2l/memorai-api#22

## Mudanças

### Configurações do Deck
- `deck/Settings.vue` — collapse com resumo no header
- Inputs de learning/relearning steps (parsing "1m 10m")
- Slider de retenção 70%–97% com explicações amigáveis

### Sessão de Revisão
- Botões mostram intervalos previstos da API (1min, 2d, 8d)
- Badges "📖 Aprendendo" (azul) / "🔄 Reaprendendo" (laranja)
- Learn ahead: card reaparece imediatamente se fila vazia
- Tela de conclusão com aviso de cards em aprendizado

### Componentes Reutilizáveis
- `ui/Modal.vue` — modal base (Teleport, ESC, click fora)
- `ui/ConfirmModal.vue` — confirmação com variantes (danger/primary)
- `flashcard/CreateModal.vue` — modal de criar card extraído

### Melhorias
- Modal de confirmação ao remover card
- Stats: "11 revisões · 4 cards" (ações vs únicos)
- Contagem correta de cards na sessão

## Build
`nuxt build` sem erros.