### PR TITLE
feat(flashcard): completar CRUD de decks e flashcards no frontend (#22)

### DIFF
--- a/app/components/deck/EditModal.vue
+++ b/app/components/deck/EditModal.vue
@@ -1,0 +1,53 @@
+<template>
+  <UiModal v-model="open" size="md" aria-label="Editar deck">
+    <h2 class="text-headline mb-4">Editar deck</h2>
+    <form @submit.prevent="submit" class="flex flex-col gap-4">
+      <div>
+        <label for="deck-name" class="text-label mb-1 block">Nome</label>
+        <input id="deck-name" v-model="form.name" type="text" class="input-base w-full" />
+      </div>
+      <div>
+        <label for="deck-desc" class="text-label mb-1 block">Descrição</label>
+        <textarea id="deck-desc" v-model="form.description" class="textarea-base" rows="2" placeholder="Opcional" />
+      </div>
+      <div class="flex gap-3 justify-end">
+        <button type="button" class="btn-secondary" @click="open = false">Cancelar</button>
+        <button type="submit" class="btn-primary" :disabled="!form.name || saving">
+          {{ saving ? 'Salvando...' : 'Salvar' }}
+        </button>
+      </div>
+    </form>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import type { Deck } from '~/types'
+
+const props = defineProps<{ deck: Deck }>()
+const emit = defineEmits<{ (e: 'updated'): void }>()
+const open = defineModel<boolean>({ required: true })
+
+const deckStore = useDeckStore()
+const toast = useToast()
+const saving = ref(false)
+const form = reactive({ name: '', description: '' })
+
+watch(() => props.deck, (d) => {
+  form.name = d.name
+  form.description = d.description ?? ''
+}, { immediate: true })
+
+async function submit() {
+  saving.value = true
+  try {
+    await deckStore.updateDeck(props.deck.id, { name: form.name, description: form.description || undefined })
+    toast.show('Deck atualizado!', 'success')
+    open.value = false
+    emit('updated')
+  } catch {
+    toast.show('Erro ao atualizar deck.', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/app/components/flashcard/EditModal.vue
+++ b/app/components/flashcard/EditModal.vue
@@ -1,0 +1,53 @@
+<template>
+  <UiModal v-model="open" size="md" aria-label="Editar flashcard">
+    <h2 class="text-headline mb-4">Editar card</h2>
+    <form @submit.prevent="submit" class="flex flex-col gap-4">
+      <div>
+        <label for="edit-front" class="text-label mb-1 block">Frente</label>
+        <textarea id="edit-front" v-model="form.front" class="textarea-base" rows="3" />
+      </div>
+      <div>
+        <label for="edit-back" class="text-label mb-1 block">Verso</label>
+        <textarea id="edit-back" v-model="form.back" class="textarea-base" rows="3" />
+      </div>
+      <div class="flex gap-3 justify-end">
+        <button type="button" class="btn-secondary" @click="open = false">Cancelar</button>
+        <button type="submit" class="btn-primary" :disabled="!form.front || !form.back || saving">
+          {{ saving ? 'Salvando...' : 'Salvar' }}
+        </button>
+      </div>
+    </form>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import type { Flashcard } from '~/types'
+
+const props = defineProps<{ card: Flashcard }>()
+const emit = defineEmits<{ (e: 'updated'): void }>()
+const open = defineModel<boolean>({ required: true })
+
+const flashcardStore = useFlashcardStore()
+const toast = useToast()
+const saving = ref(false)
+const form = reactive({ front: '', back: '' })
+
+watch(() => props.card, (c) => {
+  form.front = c.front
+  form.back = c.back
+}, { immediate: true })
+
+async function submit() {
+  saving.value = true
+  try {
+    await flashcardStore.update(props.card.id, { front: form.front, back: form.back })
+    toast.show('Card atualizado!', 'success')
+    open.value = false
+    emit('updated')
+  } catch {
+    toast.show('Erro ao atualizar card.', 'error')
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -24,6 +24,12 @@
           <button class="btn-secondary" @click="showAdd = true">
             <Plus :size="18" /> Adicionar card
           </button>
+          <button class="btn-secondary" @click="showEditDeck = true" aria-label="Editar deck">
+            <Pencil :size="18" />
+          </button>
+          <button class="btn-secondary text-danger" @click="showDeleteDeck = true" aria-label="Deletar deck">
+            <Trash2 :size="18" />
+          </button>
         </div>
       </div>
 
@@ -41,12 +47,21 @@
 
       <!-- Modals -->
       <FlashcardCreateModal v-model="showAdd" :deck-id="deckId" />
+      <FlashcardEditModal v-if="editCard" v-model="showEditCard" :card="editCard" @updated="refreshCards" />
+      <DeckEditModal v-model="showEditDeck" :deck="deckStore.current" @updated="deckStore.fetchDeck(deckId)" />
       <UiConfirmModal
         v-model="showDelete"
         title="Remover card?"
         message="Essa ação não pode ser desfeita."
         confirm-label="Remover"
-        @confirm="handleDelete"
+        @confirm="handleDeleteCard"
+      />
+      <UiConfirmModal
+        v-model="showDeleteDeck"
+        title="Deletar deck?"
+        message="Todos os cards e revisões deste deck serão perdidos permanentemente."
+        confirm-label="Deletar"
+        @confirm="handleDeleteDeck"
       />
 
       <!-- Study settings -->
@@ -72,7 +87,8 @@
               <button class="text-micro text-primary-400 hover:underline" @click="toggleCard(card.id)">
                 {{ expandedCards.has(card.id) ? 'Ocultar' : 'Ver verso' }}
               </button>
-              <button class="text-micro text-danger" @click="confirmDelete(card.id)">Remover</button>
+              <button class="text-micro text-primary-400 hover:underline" @click="openEditCard(card)">Editar</button>
+              <button class="text-micro text-danger" @click="confirmDeleteCard(card.id)">Remover</button>
             </div>
           </div>
           <Transition name="expand">
@@ -92,17 +108,22 @@
 </template>
 
 <script setup lang="ts">
-import { Play, Plus } from 'lucide-vue-next'
+import { Play, Plus, Pencil, Trash2 } from 'lucide-vue-next'
 
 const route = useRoute()
+const router = useRouter()
 const deckStore = useDeckStore()
 const flashcardStore = useFlashcardStore()
 const toast = useToast()
 
 const deckId = route.params.id as string
 const showAdd = ref(false)
+const showEditDeck = ref(false)
+const showDeleteDeck = ref(false)
+const showEditCard = ref(false)
 const showDelete = ref(false)
 const deleteTarget = ref<string | null>(null)
+const editCard = ref<import('~/types').Flashcard | null>(null)
 const expandedCards = ref(new Set<string>())
 
 function toggleCard(id: string) {
@@ -113,12 +134,12 @@ function formatDate(date: string) {
   return new Date(date).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
 }
 
-function confirmDelete(cardId: string) {
+function confirmDeleteCard(cardId: string) {
   deleteTarget.value = cardId
   showDelete.value = true
 }
 
-async function handleDelete() {
+async function handleDeleteCard() {
   if (!deleteTarget.value) return
   try {
     await flashcardStore.remove(deleteTarget.value)
@@ -129,6 +150,27 @@ async function handleDelete() {
   } finally {
     showDelete.value = false
     deleteTarget.value = null
+  }
+}
+
+function openEditCard(card: import('~/types').Flashcard) {
+  editCard.value = card
+  showEditCard.value = true
+}
+
+function refreshCards() {
+  flashcardStore.fetchForDeck(deckId)
+}
+
+async function handleDeleteDeck() {
+  try {
+    await deckStore.deleteDeck(deckId)
+    toast.show('Deck deletado.', 'success')
+    await router.push('/decks')
+  } catch {
+    toast.show('Erro ao deletar deck.', 'error')
+  } finally {
+    showDeleteDeck.value = false
   }
 }
 


### PR DESCRIPTION
Closes #22

## Mudanças

- `flashcard/EditModal.vue` — editar frente/verso do card
- `deck/EditModal.vue` — editar nome/descrição do deck
- Botões de editar (lápis) e deletar (lixeira) no header do deck
- Botão "Editar" na lista de cards
- Modal de confirmação ao deletar deck (aviso de perda permanente)
- Redireciona pra `/decks` após deletar deck

Usa os componentes reutilizáveis `UiModal` e `UiConfirmModal` criados no PR #21.
Endpoints já existem no backend — zero mudanças na API.