### PR TITLE
feat(flashcard): Fase 2.9 — Revisão Inteligente (Anti-Backlog)

### DIFF
--- a/app/components/topic/Tree.vue
+++ b/app/components/topic/Tree.vue
@@ -6,6 +6,7 @@
       :topic="topic"
       :depth="0"
       :selected-id="selectedId"
+      :progress-map="progressMap"
       @select="$emit('select', $event)"
       @edit="$emit('edit', $event)"
       @delete="$emit('delete', $event)"
@@ -23,6 +24,7 @@ import type { Topic } from '~/types'
 defineProps<{
   topics: Topic[]
   selectedId?: string | null
+  progressMap?: Record<string, number>
 }>()
 
 defineEmits<{

--- a/app/components/topic/TreeItem.vue
+++ b/app/components/topic/TreeItem.vue
@@ -15,6 +15,13 @@
       </button>
       <span v-else class="w-5" />
 
+      <!-- Health indicator -->
+      <span
+        v-if="topic.flashcards_count > 0"
+        class="w-2 h-2 rounded-full shrink-0"
+        :class="healthColor"
+      />
+
       <span class="truncate flex-1">{{ topic.name }}</span>
 
       <span class="text-micro text-base-muted shrink-0">
@@ -43,6 +50,7 @@
         :topic="child"
         :depth="depth + 1"
         :selected-id="selectedId"
+        :progress-map="progressMap"
         @select="$emit('select', $event)"
         @edit="$emit('edit', $event)"
         @delete="$emit('delete', $event)"
@@ -56,10 +64,11 @@
 import { ChevronRight, Plus, Pencil, Trash2 } from 'lucide-vue-next'
 import type { Topic } from '~/types'
 
-defineProps<{
+const props = defineProps<{
   topic: Topic
   depth: number
   selectedId?: string | null
+  progressMap?: Record<string, number>
 }>()
 
 defineEmits<{
@@ -70,4 +79,12 @@ defineEmits<{
 }>()
 
 const expanded = ref(true)
+
+const healthColor = computed(() => {
+  const p = props.progressMap?.[props.topic.id]
+  if (p === undefined) return 'bg-[#6B7280]'
+  if (p < 0.3) return 'bg-danger'
+  if (p < 0.7) return 'bg-warning'
+  return 'bg-success'
+})
 </script>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -6,6 +6,46 @@
     </h1>
     <p class="text-base-secondary mt-1">Vamos manter seu ritmo hoje.</p>
 
+    <!-- Retention suggestion banner -->
+    <div v-if="retentionSuggestion?.has_suggestion" class="mt-4 p-4 rounded-xl bg-warning/10 border border-warning/30 flex items-start gap-3">
+      <TrendingDown :size="20" class="text-warning shrink-0 mt-0.5" />
+      <div class="flex-1">
+        <p class="text-small text-base-primary">Muitas reviews acumulando? Reduzir retenção de {{ Math.round(retentionSuggestion.current_retention * 100) }}% pra {{ Math.round(retentionSuggestion.suggested_retention * 100) }}% eliminaria ~{{ retentionSuggestion.cards_eliminated }} cards hoje.</p>
+        <div class="flex gap-2 mt-2">
+          <button class="btn-primary !py-1 !px-3 !min-h-0 !text-micro" @click="applyRetention">Ajustar</button>
+          <button class="btn-secondary !py-1 !px-3 !min-h-0 !text-micro" @click="dismissRetention">Ignorar</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Survival mode suggestion -->
+    <div v-if="backlog?.suggest_survival_mode" class="mt-4 p-4 rounded-xl bg-danger/10 border border-danger/30 flex items-center gap-3">
+      <ShieldAlert :size="20" class="text-danger shrink-0" />
+      <div class="flex-1">
+        <p class="text-small text-base-primary">Backlog grande ({{ backlog.overdue_count }} cards)? Ative o Modo Sobrevivência — só os 20 mais urgentes.</p>
+      </div>
+      <button class="btn-primary !py-1 !px-3 !min-h-0 !text-micro" @click="toggleSurvivalMode(true)">Ativar</button>
+    </div>
+
+    <!-- Backlog bar -->
+    <div v-if="backlog && backlog.overdue_count > 0" class="card mt-6 flex items-center gap-4">
+      <div class="flex-1">
+        <div class="flex items-center justify-between mb-1">
+          <p class="text-small text-base-primary font-medium">Dívida de revisão</p>
+          <span class="text-micro text-base-muted">~{{ backlog.estimated_minutes }} min para zerar</span>
+        </div>
+        <div class="h-2 rounded-full bg-surface-tertiary">
+          <div
+            class="h-2 rounded-full transition-all"
+            :class="backlog.overdue_count > 50 ? 'bg-danger' : backlog.overdue_count > 10 ? 'bg-warning' : 'bg-success'"
+            :style="{ width: Math.min(100, backlog.overdue_count) + '%' }"
+          />
+        </div>
+        <p class="text-micro text-base-muted mt-1">{{ backlog.overdue_count }} cards atrasados · {{ backlog.reviews_done_today }} reviews hoje</p>
+      </div>
+      <NuxtLink to="/review" class="btn-primary !py-1.5 !px-3 !min-h-0 !text-small shrink-0">Revisar backlog</NuxtLink>
+    </div>
+
     <!-- Progress + Streak -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
       <!-- Progress card -->
@@ -127,14 +167,16 @@
 </template>
 
 <script setup lang="ts">
-import { Play, Plus, Upload, AlertCircle } from 'lucide-vue-next'
-import type { Stats, TopicProgress } from '~/types'
+import { Play, Plus, Upload, AlertCircle, ShieldAlert, TrendingDown } from 'lucide-vue-next'
+import type { Stats, TopicProgress, BacklogStats } from '~/types'
 
 const auth = useAuthStore()
 const deckStore = useDeckStore()
 
 const stats = ref<Stats | null>(null)
 const topicProgress = ref<TopicProgress[]>([])
+const backlog = ref<BacklogStats | null>(null)
+const retentionSuggestion = ref<any>(null)
 const { $api } = useNuxtApp()
 
 const greeting = computed(() => {
@@ -154,13 +196,40 @@ const progressPercent = computed(() => {
 })
 
 async function loadData() {
-  const [statsRes, , progressRes] = await Promise.all([
+  const [statsRes, , progressRes, backlogRes, retRes] = await Promise.all([
     $api<any>('/stats'),
     deckStore.fetchDecks(),
     $api<any>('/topics/progress'),
+    $api<any>('/review/backlog-stats'),
+    $api<any>('/review/retention-suggestion').catch(() => ({ data: { has_suggestion: false } })),
   ])
   stats.value = statsRes.data
   topicProgress.value = progressRes.data
+  backlog.value = backlogRes.data
+  retentionSuggestion.value = retRes.data
+}
+
+async function toggleSurvivalMode(enabled: boolean) {
+  try {
+    await $api('/review/survival-mode', { method: 'POST', body: { enabled } })
+    await loadData()
+  } catch {}
+}
+
+async function applyRetention() {
+  if (!retentionSuggestion.value?.suggested_retention) return
+  try {
+    await $api('/review/apply-retention', {
+      method: 'POST',
+      body: { desired_retention: retentionSuggestion.value.suggested_retention },
+    })
+    retentionSuggestion.value = { has_suggestion: false }
+    await loadData()
+  } catch {}
+}
+
+function dismissRetention() {
+  retentionSuggestion.value = { has_suggestion: false }
 }
 
 onMounted(loadData)

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -5,7 +5,10 @@
       <NuxtLink to="/dashboard" class="text-small text-base-muted hover:text-accent-primary">
         ← Voltar
       </NuxtLink>
-      <div class="flex items-center gap-2 text-small text-base-secondary">
+      <div class="flex items-center gap-3 text-small text-base-secondary">
+        <span v-if="sessionTimer > 0" class="text-micro font-mono" :class="sessionTimer <= 60 ? 'text-danger' : 'text-base-muted'">
+          ⏱ {{ formatTimer(sessionTimer) }}
+        </span>
         <span>{{ review.reviewed }} / {{ review.total }}</span>
         <div class="w-32 h-1.5 rounded-full bg-surface-tertiary">
           <div class="h-1.5 rounded-full bg-primary-500 transition-all duration-300" :style="{ width: review.progress + '%' }" />
@@ -96,6 +99,17 @@
         @saved="review.showErrorDiary = false"
         @skipped="review.showErrorDiary = false"
       />
+      <!-- Note snippet (reverse linking) -->
+      <div v-if="review.noteSnippet" class="mt-4 w-full max-w-md p-3 rounded-lg bg-accent-primary-subtle border border-accent-primary/20">
+        <p class="text-micro text-accent-primary font-medium mb-1">📝 Da sua nota: {{ review.noteSnippet.title }}</p>
+        <p class="text-small text-base-secondary">{{ review.noteSnippet.snippet }}</p>
+        <NuxtLink
+          :to="`/topics?topic=${review.noteSnippet.topic_id}&note=${review.noteSnippet.note_id}`"
+          class="text-micro text-accent-primary hover:underline mt-1 inline-block"
+        >
+          Ver nota completa →
+        </NuxtLink>
+      </div>
     </div>
   </div>
 </template>
@@ -128,6 +142,35 @@ async function loadSession() {
   const errorsOnly = route.query.errors_only === '1'
   if (deckId) await deckStore.fetchDeck(deckId)
   await review.fetchSession(deckId, topicId, errorsOnly)
+  await loadSessionTimer()
+}
+
+// Session timer
+const sessionTimer = ref(0)
+let timerInterval: ReturnType<typeof setInterval> | null = null
+const showTimeUp = ref(false)
+
+async function loadSessionTimer() {
+  try {
+    const { $api } = useNuxtApp()
+    const res = await $api<any>('/settings')
+    const limit = res.data.session_time_limit
+    if (limit) {
+      sessionTimer.value = limit * 60
+      timerInterval = setInterval(() => {
+        if (sessionTimer.value > 0) {
+          sessionTimer.value--
+          if (sessionTimer.value === 0) showTimeUp.value = true
+        }
+      }, 1000)
+    }
+  } catch {}
+}
+
+function formatTimer(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
 }
 
 onMounted(loadSession)
@@ -141,6 +184,7 @@ onMounted(() => {
 })
 onUnmounted(() => {
   if (tickInterval) clearInterval(tickInterval)
+  if (timerInterval) clearInterval(timerInterval)
 })
 
 watch(() => route.query, (newQ, oldQ) => {

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -50,6 +50,46 @@
       </div>
     </section>
 
+    <!-- Sessão de Estudo -->
+    <section class="card p-5 mb-6">
+      <h2 class="text-headline mb-1">Sessão de Estudo</h2>
+      <p class="text-micro text-base-muted mb-4">Controle a carga diária de revisão para evitar sobrecarga.</p>
+
+      <div class="space-y-4">
+        <div>
+          <div class="flex items-center justify-between mb-1">
+            <label class="text-label">Novos cards por dia</label>
+            <label class="flex items-center gap-1.5 text-micro text-base-muted cursor-pointer">
+              <input type="checkbox" :checked="settings.daily_new_cards_limit === null" @change="settings.daily_new_cards_limit = ($event.target as HTMLInputElement).checked ? null : 20" class="accent-[#522A6F]" />
+              Ilimitado
+            </label>
+          </div>
+          <input v-if="settings.daily_new_cards_limit !== null" v-model.number="settings.daily_new_cards_limit" type="number" min="1" max="999" class="input-base w-32" />
+          <p class="text-micro text-base-muted mt-1">Cada novo card gera ~7-10 revisões no mês seguinte.</p>
+        </div>
+
+        <div>
+          <div class="flex items-center justify-between mb-1">
+            <label class="text-label">Máximo de revisões por dia</label>
+            <label class="flex items-center gap-1.5 text-micro text-base-muted cursor-pointer">
+              <input type="checkbox" :checked="settings.daily_review_limit === null" @change="settings.daily_review_limit = ($event.target as HTMLInputElement).checked ? null : 100" class="accent-[#522A6F]" />
+              Ilimitado
+            </label>
+          </div>
+          <input v-if="settings.daily_review_limit !== null" v-model.number="settings.daily_review_limit" type="number" min="1" max="9999" class="input-base w-32" />
+        </div>
+
+        <div>
+          <label class="text-label mb-1 block">Limite de tempo por sessão</label>
+          <UiSelect v-model="sessionTimeStr" :options="timeOptions" placeholder="Sem limite" />
+        </div>
+
+        <button class="btn-primary !py-1.5 !px-4 !min-h-0 !text-small" :disabled="savingSettings" @click="saveSettings">
+          {{ savingSettings ? 'Salvando...' : 'Salvar configurações' }}
+        </button>
+      </div>
+    </section>
+
     <!-- Conta -->
     <section class="card p-5">
       <h2 class="text-headline mb-4">Conta</h2>
@@ -62,10 +102,52 @@
 
 <script setup lang="ts">
 import { Moon, Sun, LogOut } from 'lucide-vue-next'
+import type { UserSettings } from '~/types'
 
 const auth = useAuthStore()
 const { colorMode, set } = useColorMode()
 const toast = useToast()
+const { $api } = useNuxtApp()
+
+const settings = reactive<UserSettings>({
+  daily_new_cards_limit: 20,
+  daily_review_limit: null,
+  session_time_limit: null,
+  survival_mode: false,
+})
+const savingSettings = ref(false)
+
+const sessionTimeStr = computed({
+  get: () => settings.session_time_limit?.toString() ?? '',
+  set: (v: string) => { settings.session_time_limit = v ? parseInt(v) : null },
+})
+
+const timeOptions = [
+  { value: '', label: 'Sem limite' },
+  { value: '5', label: '5 minutos' },
+  { value: '10', label: '10 minutos' },
+  { value: '15', label: '15 minutos' },
+  { value: '30', label: '30 minutos' },
+]
+
+async function loadSettings() {
+  try {
+    const res = await $api<any>('/settings')
+    Object.assign(settings, res.data)
+  } catch {}
+}
+
+async function saveSettings() {
+  savingSettings.value = true
+  try {
+    await $api('/settings', { method: 'PUT', body: { ...settings } })
+    toast.show('Configurações salvas!', 'success')
+  } catch {
+    toast.show('Erro ao salvar.', 'error')
+  } finally {
+    savingSettings.value = false
+  }
+}
 
 function setMode(mode: 'light' | 'dark') {
   set(mode)
@@ -84,6 +166,7 @@ async function handleLogout() {
 }
 
 onMounted(async () => {
+  await loadSettings()
   if (!auth.user && auth.token) {
     try {
       const { $api } = useNuxtApp()

--- a/app/pages/topics/index.vue
+++ b/app/pages/topics/index.vue
@@ -16,6 +16,7 @@
           v-else
           :topics="topicStore.tree"
           :selected-id="selectedTopicId"
+          :progress-map="progressMap"
           @select="selectTopic"
           @edit="openEdit"
           @delete="openDelete"
@@ -106,6 +107,37 @@
 
         <!-- Tab: Errors -->
         <div v-else-if="activeTab === 'errors'" class="flex-1 overflow-y-auto p-4">
+          <!-- Error patterns -->
+          <div v-if="errorPatterns && errorPatterns.total_errors > 0" class="mb-6">
+            <p class="text-label mb-3">Padrões de erro (últimos 30 dias)</p>
+            <div class="space-y-2">
+              <div v-for="(count, reason) in errorPatterns.patterns" :key="reason" class="flex items-center gap-3">
+                <span class="text-base shrink-0">{{ reasonIcon(reason as string) }}</span>
+                <span class="text-small text-base-primary w-24">{{ reasonLabel(reason as string) }}</span>
+                <div class="flex-1 h-2 rounded-full bg-surface-tertiary">
+                  <div class="h-2 rounded-full bg-danger transition-all" :style="{ width: Math.round((count as number / errorPatterns.total_errors) * 100) + '%' }" />
+                </div>
+                <span class="text-micro text-base-muted w-8 text-right">{{ count }}x</span>
+              </div>
+            </div>
+            <div v-if="errorPatterns.top_cards.length" class="mt-4">
+              <p class="text-label mb-2">Cards mais errados</p>
+              <div class="space-y-1">
+                <div v-for="card in errorPatterns.top_cards" :key="card.id" class="flex items-center gap-2 text-small">
+                  <span class="text-danger font-medium">{{ card.lapses }}x</span>
+                  <span class="text-base-secondary truncate">{{ card.front }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Error log list -->
+          <div v-if="topicErrors.length" class="flex items-center justify-between mb-2">
+            <p class="text-label">Histórico de erros</p>
+            <NuxtLink :to="`/review?topic_id=${selectedTopicId}&errors_only=1`" class="btn-primary !py-1 !px-3 !min-h-0 !text-micro">
+              Revisar erros deste tópico
+            </NuxtLink>
+          </div>
           <div v-if="topicErrors.length" class="space-y-2">
             <div v-for="err in topicErrors" :key="err.id" class="card flex items-start gap-3">
               <span class="text-base shrink-0">{{ reasonIcon(err.reason) }}</span>
@@ -116,7 +148,7 @@
               </div>
             </div>
           </div>
-          <div v-else class="flex items-center justify-center h-full text-base-muted text-small">
+          <div v-if="!topicErrors.length && (!errorPatterns || errorPatterns.total_errors === 0)" class="flex items-center justify-center h-full text-base-muted text-small">
             Nenhum erro registrado neste tópico.
           </div>
         </div>
@@ -247,6 +279,7 @@ const selectedText = ref('')
 const topicErrors = ref<any[]>([])
 const topicCards = ref<any[]>([])
 const checklistItems = ref<any[]>([])
+const errorPatterns = ref<any>(null)
 const newChecklistText = ref('')
 const tabs = [
   { id: 'notes' as const, label: 'Notas' },
@@ -323,14 +356,16 @@ function selectTopic(id: string) {
 
 async function loadTopicData(id: string) {
   try {
-    const [errRes, detailRes, checkRes] = await Promise.all([
+    const [errRes, detailRes, checkRes, patternsRes] = await Promise.all([
       $api<any>(`/topics/${id}/error-logs`),
       $api<any>(`/topics/${id}/details`),
       $api<any>(`/topics/${id}/checklist`),
+      $api<any>(`/topics/${id}/error-patterns`),
     ])
     topicErrors.value = errRes.data
     topicCards.value = detailRes.data.flashcards
     checklistItems.value = checkRes.data
+    errorPatterns.value = patternsRes.data
   } catch {}
 }
 
@@ -367,6 +402,11 @@ async function deleteChecklistItem(id: string) {
 function reasonIcon(reason: string): string {
   const map: Record<string, string> = { confused: '🔄', didnt_know: '❓', forgot: '🧠', silly_mistake: '😅' }
   return map[reason] ?? '❌'
+}
+
+function reasonLabel(reason: string): string {
+  const map: Record<string, string> = { confused: 'Confundi', didnt_know: 'Não sabia', forgot: 'Esqueci', silly_mistake: 'Erro bobo' }
+  return map[reason] ?? reason
 }
 
 function cardStateLabel(state: string): string {
@@ -448,8 +488,16 @@ function formatDate(date: string) {
   return new Date(date).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' })
 }
 
+const progressMap = ref<Record<string, number>>({})
+
 onMounted(async () => {
   await topicStore.fetchTree()
+  try {
+    const res = await $api<any>('/topics/progress')
+    for (const tp of res.data) {
+      progressMap.value[tp.id] = tp.progress
+    }
+  } catch {}
   const route = useRoute()
   if (route.query.topic) {
     selectTopic(route.query.topic as string)

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -15,6 +15,7 @@ export const useReviewStore = defineStore('review', {
     submitting: false,
     finished: false,
     weakSuggestion: null as WeakConnection[] | null,
+    noteSnippet: null as { note_id: string; title: string; snippet: string; topic_id: string } | null,
     lastReviewId: null as string | null,
     showErrorDiary: false,
     _tick: 0,
@@ -48,6 +49,7 @@ export const useReviewStore = defineStore('review', {
       this.flipped = false
       this.learningQueue = []
       this.weakSuggestion = null
+      this.noteSnippet = null
       this.showErrorDiary = false
       try {
         const { $api } = useNuxtApp()
@@ -81,6 +83,7 @@ export const useReviewStore = defineStore('review', {
 
         // Weak connection suggestion on Again
         this.weakSuggestion = res.data.weak_connections ?? null
+        this.noteSnippet = res.data.note_snippet ?? null
 
         // Show error diary on Again
         this.lastReviewId = res.data.review?.id ?? null

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -157,3 +157,34 @@ export interface ErrorLog {
   note: string | null
   created_at: string
 }
+
+
+export interface UserSettings {
+  daily_new_cards_limit: number | null
+  daily_review_limit: number | null
+  session_time_limit: number | null
+  survival_mode: boolean
+}
+
+export interface BacklogStats {
+  overdue_count: number
+  due_today_count: number
+  new_available_count: number | null
+  estimated_minutes: number
+  reviews_done_today: number
+  new_cards_done_today: number
+  suggest_survival_mode: boolean
+}
+
+export interface ErrorPatterns {
+  patterns: Record<string, number>
+  total_errors: number
+  top_cards: { id: string; front: string; lapses: number }[]
+}
+
+export interface NoteSnippet {
+  note_id: string
+  title: string
+  snippet: string
+  topic_id: string
+}

--- a/tests/stores/review.test.ts
+++ b/tests/stores/review.test.ts
@@ -13,6 +13,7 @@ describe('useReviewStore', () => {
     expect(store.currentIndex).toBe(0)
     expect(store.flipped).toBe(false)
     expect(store.finished).toBe(false)
+    expect(store.noteSnippet).toBeNull()
   })
 
   it('currentCard returns null when empty', () => {
@@ -29,5 +30,64 @@ describe('useReviewStore', () => {
     const store = useReviewStore()
     store.flip()
     expect(store.flipped).toBe(true)
+  })
+
+  it('currentCard returns from main queue', () => {
+    const store = useReviewStore()
+    const card = { id: '1', next_intervals: { again: '1min', hard: '1min', good: '10min', easy: '8d' } } as any
+    store.cards = [card]
+    expect(store.currentCard?.id).toBe('1')
+  })
+
+  it('currentCard returns due learning card over main queue', () => {
+    const store = useReviewStore()
+    const mainCard = { id: 'main', next_intervals: {} } as any
+    const learnCard = { id: 'learn', next_intervals: {} } as any
+    store.cards = [mainCard]
+    store.learningQueue = [{ card: learnCard, dueAt: Date.now() - 1000 }]
+    expect(store.currentCard?.id).toBe('learn')
+  })
+
+  it('currentCard skips future learning cards', () => {
+    const store = useReviewStore()
+    const mainCard = { id: 'main', next_intervals: {} } as any
+    const futureCard = { id: 'future', next_intervals: {} } as any
+    store.cards = [mainCard]
+    store.learningQueue = [{ card: futureCard, dueAt: Date.now() + 60000 }]
+    expect(store.currentCard?.id).toBe('main')
+  })
+
+  it('checkFinished does not finish when learning queue has items', () => {
+    const store = useReviewStore()
+    store.cards = [{ id: '1' } as any]
+    store.currentIndex = 1
+    store.learningQueue = [{ card: { id: '2' } as any, dueAt: Date.now() + 60000 }]
+    store.checkFinished()
+    expect(store.finished).toBe(false)
+  })
+
+  it('checkFinished finishes when both queues empty', () => {
+    const store = useReviewStore()
+    store.cards = [{ id: '1' } as any]
+    store.currentIndex = 1
+    store.learningQueue = []
+    store.checkFinished()
+    expect(store.finished).toBe(true)
+  })
+
+  it('pendingLearning returns queue length', () => {
+    const store = useReviewStore()
+    store.learningQueue = [
+      { card: {} as any, dueAt: Date.now() },
+      { card: {} as any, dueAt: Date.now() },
+    ]
+    expect(store.pendingLearning).toBe(2)
+  })
+
+  it('_tick is reactive for learning queue re-evaluation', () => {
+    const store = useReviewStore()
+    expect(store._tick).toBe(0)
+    store._tick++
+    expect(store._tick).toBe(1)
   })
 })


### PR DESCRIPTION
Closes #26

## O que foi feito

- Configurações de sessão em /settings
- Barra de dívida no dashboard (verde/amarelo/vermelho)
- Banner sugestão de retenção + banner modo sobrevivência
- Timer regressivo na sessão de revisão
- Padrões de erro na tab Erros (barras horizontais + top cards)
- Reverse linking (snippet da nota abaixo do ErrorDiary)
- Bolinha de saúde na árvore de tópicos (vermelho/amarelo/verde)
- Botão "Revisar erros deste tópico"
- Tipos: UserSettings, BacklogStats, ErrorPatterns, NoteSnippet

## Testes

20 testes frontend — todos passando (7 novos no review store)