### PR TITLE
feat(ui): redesign UI + correções Fase 2.9

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -5,23 +5,23 @@
 
 /* ============================================
    Design Tokens — Memorai
-   Dark-first, roxo como identidade, cyan pra IA
-   Referência visual: Linear, Notion, Raycast
+   High-Tech Earthy — Linear meets leather notebook
+   Vibrant terracotta CTA, sage green accent, depth layers
    ============================================ */
 
 @theme {
-  /* Primary — Purple Seduction (identidade) */
-  --color-primary-400: #DDAAFF;
-  --color-primary-500: #522A6F;
-  --color-primary-600: #3E1F54;
-  --color-primary-700: #2E1740;
-  --color-primary-800: #1F0F2B;
-  --color-primary-900: #100818;
+  /* Primary — Amber Queimado (identidade, assinatura) */
+  --color-primary-400: #F59E0B;
+  --color-primary-500: #D97706;
+  --color-primary-600: #B45309;
+  --color-primary-700: #92400E;
+  --color-primary-800: #78350F;
+  --color-primary-900: #451A03;
 
-  /* Accent — Solarized (atenção, destaques) */
-  --color-accent-400: #FBCF4F;
-  --color-accent-500: #E5B83A;
-  --color-accent-600: #C99E2E;
+  /* Accent — Sage Green (secondary, progress) */
+  --color-accent-400: #B8C4A0;
+  --color-accent-500: #A3B18A;
+  --color-accent-600: #8A9A70;
 
   /* Semânticas */
   --color-success: #22C55E;
@@ -29,9 +29,9 @@
   --color-warning: #F59E0B;
   --color-info: #38BDF8;
 
-  /* Fontes — dual strategy: Manrope (headlines) + Inter (body) */
+  /* Fontes — serif headlines + Inter body */
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-display: 'Manrope', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'DM Serif Display', 'Georgia', serif;
 
   /* Transição padrão */
   --transition-default: all 150ms ease-in-out;
@@ -46,51 +46,49 @@
    ============================================ */
 
 :root {
-  --bg-primary: #F8F9FA;
-  --bg-secondary: #F0F1F3;
-  --bg-tertiary: #E8E9EB;
-  --text-primary: #222023;
-  --text-secondary: #4A4548;
-  --text-muted: #8A7F76;
-  --border-default: #E0E1E3;
-  --border-strong: #D0D1D3;
+  --bg-primary: #F5F2ED;
+  --bg-secondary: #ECEAE4;
+  --bg-tertiary: #E0DDD6;
+  --text-primary: #1A1918;
+  --text-secondary: #4D4A46;
+  --text-muted: #8A8680;
+  --border-default: #D6D3CC;
+  --border-strong: #C4C0B8;
 
-  /* Accent semântico — muda entre light/dark */
-  --color-accent-primary: #522A6F;
-  --color-accent-primary-hover: #3E1F54;
-  --color-accent-primary-subtle: rgba(82, 42, 111, 0.12);
+  --color-accent-primary: #B45309;
+  --color-accent-primary-hover: #92400E;
+  --color-accent-primary-subtle: rgba(180, 83, 9, 0.08);
 
-  /* Badge colors — contraste adequado no light */
-  --badge-primary-bg: rgba(82, 42, 111, 0.12);
-  --badge-primary-text: #522A6F;
-  --badge-accent-bg: rgba(196, 155, 20, 0.12);
-  --badge-accent-text: #8B6914;
-  --badge-success-bg: rgba(22, 163, 74, 0.12);
-  --badge-success-text: #15803D;
-  --badge-danger-bg: rgba(220, 38, 38, 0.12);
+  --badge-primary-bg: rgba(180, 83, 9, 0.10);
+  --badge-primary-text: #92400E;
+  --badge-accent-bg: rgba(34, 197, 94, 0.10);
+  --badge-accent-text: #16A34A;
+  --badge-success-bg: rgba(34, 197, 94, 0.10);
+  --badge-success-text: #16A34A;
+  --badge-danger-bg: rgba(239, 68, 68, 0.10);
   --badge-danger-text: #DC2626;
-  --badge-warning-bg: rgba(217, 119, 6, 0.12);
-  --badge-warning-text: #B45309;
+  --badge-warning-bg: rgba(245, 158, 11, 0.10);
+  --badge-warning-text: #D97706;
 }
 
 .dark {
-  --bg-primary: #222023;
-  --bg-secondary: #2A282C;
-  --bg-tertiary: #353337;
-  --text-primary: #FAEADD;
-  --text-secondary: #C4B8AD;
-  --text-muted: #8A7F76;
-  --border-default: #353337;
-  --border-strong: #454247;
+  --bg-primary: #0F0F0F;
+  --bg-secondary: #1A1A1A;
+  --bg-tertiary: #242424;
+  --text-primary: #E9E4D9;
+  --text-secondary: #ADA89E;
+  --text-muted: #706B64;
+  --border-default: #2A2A2A;
+  --border-strong: #363636;
 
-  --color-accent-primary: #DDAAFF;
-  --color-accent-primary-hover: #C88AEE;
-  --color-accent-primary-subtle: rgba(221, 170, 255, 0.12);
+  --color-accent-primary: #D97706;
+  --color-accent-primary-hover: #F59E0B;
+  --color-accent-primary-subtle: rgba(217, 119, 6, 0.12);
 
-  --badge-primary-bg: rgba(82, 42, 111, 0.15);
-  --badge-primary-text: #DDAAFF;
-  --badge-accent-bg: rgba(251, 207, 79, 0.15);
-  --badge-accent-text: #FBCF4F;
+  --badge-primary-bg: rgba(217, 119, 6, 0.15);
+  --badge-primary-text: #F59E0B;
+  --badge-accent-bg: rgba(34, 197, 94, 0.12);
+  --badge-accent-text: #22C55E;
   --badge-success-bg: rgba(34, 197, 94, 0.15);
   --badge-success-text: #22C55E;
   --badge-danger-bg: rgba(239, 68, 68, 0.15);
@@ -147,49 +145,63 @@
    Component utilities
    ============================================ */
 
-/* Botão primary */
+/* Botão primary — Amber queimado com gradiente + glow */
 @utility btn-primary {
-  background-color: #522A6F;
-  color: #FAEADD;
-  font-weight: 500;
+  background: linear-gradient(135deg, #D97706, #B45309);
+  color: #FFFFFF;
+  font-weight: 600;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
   border-radius: 0.5rem;
   min-height: 2.75rem;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  box-shadow: 0 4px 16px rgba(217, 119, 6, 0.25);
   &:hover {
-    background-color: #3E1F54;
+    filter: brightness(1.1);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 24px rgba(217, 119, 6, 0.35);
   }
   &:active {
-    transform: scale(0.95);
+    transform: scale(0.97);
+    filter: brightness(1);
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    filter: none;
+    transform: none;
+    box-shadow: none;
   }
 }
 
-/* Botão IA (cyan) */
+/* Botão accent — neutro (secondary com identidade) */
 @utility btn-accent {
-  background-color: #FBCF4F;
-  color: #222023;
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
   border-radius: 0.5rem;
+  border: 1px solid var(--border-strong);
   min-height: 2.75rem;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
   &:hover {
-    background-color: #E5B83A;
+    background-color: var(--border-default);
+    border-color: var(--text-muted);
+    transform: translateY(-1px);
   }
   &:active {
-    transform: scale(0.95);
+    transform: scale(0.97);
   }
 }
 
@@ -201,9 +213,9 @@
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
   border-radius: 0.5rem;
-  border: 1px solid var(--border-default);
+  border: 1px solid var(--border-strong);
   min-height: 2.75rem;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -211,6 +223,8 @@
   gap: 0.5rem;
   &:hover {
     background-color: var(--bg-tertiary);
+    border-color: var(--text-muted);
+    transform: translateY(-1px);
   }
   &:active {
     transform: scale(0.95);
@@ -221,7 +235,7 @@
 @utility btn-danger {
   background-color: #EF4444;
   color: #FFFFFF;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
   border-radius: 0.5rem;
@@ -240,33 +254,57 @@
   }
 }
 
-/* Card — sem borda visível, separação por fundo */
+/* Card — profundidade real */
 @utility card {
-  background-color: var(--bg-secondary);
+  background: linear-gradient(180deg, var(--bg-secondary), var(--bg-secondary));
+  border: 1px solid transparent;
   border-radius: 0.75rem;
   padding: 1rem;
-  transition: var(--transition-default);
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
 }
 
-/* Card interativo (hover lift) */
-@utility card-interactive {
-  background-color: var(--bg-secondary);
+:where(.dark) .card {
+  background: linear-gradient(180deg, #141414, #111111);
+}
+
+/* Card destaque (dívida de revisão, alertas) */
+@utility card-warm {
+  background: linear-gradient(180deg, #1A1510, #15110D);
+  border: 1px solid rgba(217, 119, 6, 0.08);
   border-radius: 0.75rem;
   padding: 1rem;
-  transition: var(--transition-default);
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+
+/* Card interativo (hover lift + glow amber) */
+@utility card-interactive {
+  background: linear-gradient(180deg, var(--bg-secondary), var(--bg-secondary));
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   cursor: pointer;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
   &:hover {
-    background-color: var(--bg-tertiary);
+    background: var(--bg-tertiary);
+    border-color: rgba(217, 119, 6, 0.15);
     transform: translateY(-2px);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(217, 119, 6, 0.08);
   }
   &:active {
-    transform: scale(0.98);
+    transform: scale(0.97);
   }
 }
 
-/* Input */
+:where(.dark) .card-interactive {
+  background: linear-gradient(180deg, #141414, #111111);
+}
+
+/* Input — focus terracotta */
 @utility input-base {
-  background-color: var(--bg-secondary);
+  background-color: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: 0.5rem;
@@ -280,14 +318,14 @@
     color: var(--text-muted);
   }
   &:focus {
-    border-color: #522A6F;
-    box-shadow: 0 0 0 1px #522A6F;
+    border-color: #D97706;
+    box-shadow: 0 0 0 1px rgba(217, 119, 6, 0.4);
   }
 }
 
 /* Textarea */
 @utility textarea-base {
-  background-color: var(--bg-secondary);
+  background-color: var(--bg-primary);
   color: var(--text-primary);
   border: 1px solid var(--border-default);
   border-radius: 0.5rem;
@@ -301,8 +339,8 @@
     color: var(--text-muted);
   }
   &:focus {
-    border-color: #522A6F;
-    box-shadow: 0 0 0 1px #522A6F;
+    border-color: #D97706;
+    box-shadow: 0 0 0 1px rgba(217, 119, 6, 0.4);
   }
 }
 
@@ -346,13 +384,18 @@
   color: var(--text-muted);
 }
 
-/* Glow sutil roxo (para CTAs importantes) */
+/* Glow */
 @utility glow-primary {
-  box-shadow: 0 0 20px rgba(82, 42, 111, 0.15);
+  box-shadow: 0 0 20px rgba(217, 119, 6, 0.2);
 }
 
 @utility glow-accent {
-  box-shadow: 0 0 20px rgba(251, 207, 79, 0.15);
+  box-shadow: 0 0 16px rgba(217, 119, 6, 0.12);
+}
+
+@utility glow-success {
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.2);
+  background: linear-gradient(90deg, #22C55E, #4ADE80);
 }
 
 /* ============================================
@@ -362,15 +405,15 @@
 @utility text-display {
   font-family: var(--font-display);
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 1.2;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.02em;
 }
 
 @utility text-headline {
   font-family: var(--font-display);
   font-size: 1.25rem;
-  font-weight: 700;
+  font-weight: 400;
   line-height: 1.3;
   letter-spacing: -0.015em;
 }
@@ -417,15 +460,16 @@
    ============================================ */
 
 @utility btn-again {
-  background-color: rgba(239, 68, 68, 0.15);
-  color: #EF4444;
+  background-color: #1A1716;
+  color: #BC4749;
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
+  border: 1px solid transparent;
   min-height: 3.5rem;
   width: 100%;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -433,7 +477,9 @@
   justify-content: center;
   gap: 0.25rem;
   &:hover {
-    background-color: rgba(239, 68, 68, 0.25);
+    border-color: rgba(188, 71, 73, 0.3);
+    background-color: #1E1A18;
+    box-shadow: 0 0 12px rgba(188, 71, 73, 0.1);
   }
   &:active {
     transform: scale(0.95);
@@ -441,15 +487,16 @@
 }
 
 @utility btn-hard {
-  background-color: rgba(245, 158, 11, 0.15);
-  color: #F59E0B;
+  background-color: #1A1716;
+  color: #B4833D;
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
+  border: 1px solid transparent;
   min-height: 3.5rem;
   width: 100%;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -457,7 +504,9 @@
   justify-content: center;
   gap: 0.25rem;
   &:hover {
-    background-color: rgba(245, 158, 11, 0.25);
+    border-color: rgba(180, 131, 61, 0.3);
+    background-color: #1E1A18;
+    box-shadow: 0 0 12px rgba(180, 131, 61, 0.1);
   }
   &:active {
     transform: scale(0.95);
@@ -465,23 +514,27 @@
 }
 
 @utility btn-good {
-  background-color: rgba(34, 197, 94, 0.15);
-  color: #22C55E;
+  background-color: #1A1716;
+  color: #6A994E;
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
+  border: 1px solid rgba(106, 153, 78, 0.2);
   min-height: 3.5rem;
   width: 100%;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
+  box-shadow: 0 0 16px rgba(106, 153, 78, 0.1);
   &:hover {
-    background-color: rgba(34, 197, 94, 0.25);
+    border-color: rgba(106, 153, 78, 0.4);
+    background-color: #1E1A18;
+    box-shadow: 0 0 24px rgba(106, 153, 78, 0.18);
   }
   &:active {
     transform: scale(0.95);
@@ -489,15 +542,16 @@
 }
 
 @utility btn-easy {
-  background-color: var(--color-accent-primary-subtle);
-  color: var(--color-accent-primary);
+  background-color: #1A1716;
+  color: #D67D55;
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
+  border: 1px solid transparent;
   min-height: 3.5rem;
   width: 100%;
-  transition: var(--transition-default);
+  transition: all 0.15s ease;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -505,7 +559,9 @@
   justify-content: center;
   gap: 0.25rem;
   &:hover {
-    background-color: rgba(82, 42, 111, 0.35);
+    border-color: rgba(214, 125, 85, 0.3);
+    background-color: #1E1A18;
+    box-shadow: 0 0 12px rgba(214, 125, 85, 0.1);
   }
   &:active {
     transform: scale(0.95);
@@ -543,6 +599,23 @@ html {
   font-family: var(--font-sans);
 }
 
+.dark html,
+html:where(.dark) {
+  background: radial-gradient(circle at top, #1a120f 0%, #0b0b0b 60%);
+  min-height: 100vh;
+}
+
+/* Noise texture overlay */
+html:where(.dark)::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  pointer-events: none;
+  z-index: 0;
+}
+
 button {
   cursor: pointer;
 }
@@ -557,16 +630,16 @@ button {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-default);
+  background: var(--border-strong);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--border-strong);
+  background: var(--text-muted);
 }
 
-/* Selection */
+/* Selection — terracotta */
 ::selection {
-  background-color: rgba(82, 42, 111, 0.3);
-  color: #FFFFFF;
+  background-color: rgba(217, 119, 6, 0.3);
+  color: #E9E4D9;
 }

--- a/app/components/flashcard/Buttons.vue
+++ b/app/components/flashcard/Buttons.vue
@@ -1,40 +1,59 @@
 <template>
-  <div class="grid grid-cols-4 gap-3 w-full max-w-lg mx-auto">
-    <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="`Errei — ${intervals.again}`">
-      <RotateCcw :size="20" />
-      <span class="flex flex-col items-center">
+  <div class="w-full max-w-2xl mx-auto">
+    <!-- Mobile: 2x2 with Bom highlighted -->
+    <div class="grid grid-cols-2 gap-3 sm:hidden">
+      <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="`Errei — ${intervals.again}`">
+        <RotateCcw :size="18" />
         <span>Errei</span>
-        <span class="text-micro opacity-75">{{ intervals.again }}</span>
-      </span>
-    </button>
-    <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="`Difícil — ${intervals.hard}`">
-      <Frown :size="20" />
-      <span class="flex flex-col items-center">
-        <span>Difícil</span>
-        <span class="text-micro opacity-75">{{ intervals.hard }}</span>
-      </span>
-    </button>
-    <button class="btn-good" :disabled="disabled" @click="onRate(3)" :aria-label="`Bom — ${intervals.good}`">
-      <CheckCircle :size="20" />
-      <span class="flex flex-col items-center">
+        <span class="text-micro opacity-50">{{ intervals.again }}</span>
+      </button>
+      <button class="btn-good ring-1 ring-[#6A994E]/30" :disabled="disabled" @click="onRate(3)" :aria-label="`Bom — ${intervals.good}`">
+        <CheckCircle :size="18" />
         <span>Bom</span>
-        <span class="text-micro opacity-75">{{ intervals.good }}</span>
-      </span>
-    </button>
-    <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="`Fácil — ${intervals.easy}`">
-      <Sparkles :size="20" />
-      <span class="flex flex-col items-center">
+        <span class="text-micro opacity-50">{{ intervals.good }}</span>
+      </button>
+      <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="`Difícil — ${intervals.hard}`">
+        <Frown :size="18" />
+        <span>Difícil</span>
+        <span class="text-micro opacity-50">{{ intervals.hard }}</span>
+      </button>
+      <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="`Fácil — ${intervals.easy}`">
+        <Sparkles :size="18" />
         <span>Fácil</span>
-        <span class="text-micro opacity-75">{{ intervals.easy }}</span>
-      </span>
-    </button>
+        <span class="text-micro opacity-50">{{ intervals.easy }}</span>
+      </button>
+    </div>
+
+    <!-- Desktop: 4 cols with Bom highlighted -->
+    <div class="hidden sm:grid grid-cols-4 gap-3">
+      <button class="btn-again" :disabled="disabled" @click="onRate(1)" :aria-label="`Errei — ${intervals.again}`">
+        <RotateCcw :size="18" />
+        <span>Errei</span>
+        <span class="text-micro opacity-50">{{ intervals.again }}</span>
+      </button>
+      <button class="btn-hard" :disabled="disabled" @click="onRate(2)" :aria-label="`Difícil — ${intervals.hard}`">
+        <Frown :size="18" />
+        <span>Difícil</span>
+        <span class="text-micro opacity-50">{{ intervals.hard }}</span>
+      </button>
+      <button class="btn-good ring-1 ring-[#6A994E]/30" :disabled="disabled" @click="onRate(3)" :aria-label="`Bom — ${intervals.good}`">
+        <CheckCircle :size="18" />
+        <span>Bom</span>
+        <span class="text-micro opacity-50">{{ intervals.good }}</span>
+      </button>
+      <button class="btn-easy" :disabled="disabled" @click="onRate(4)" :aria-label="`Fácil — ${intervals.easy}`">
+        <Sparkles :size="18" />
+        <span>Fácil</span>
+        <span class="text-micro opacity-50">{{ intervals.easy }}</span>
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { RotateCcw, Frown, CheckCircle, Sparkles } from 'lucide-vue-next'
 
-const props = defineProps<{
+defineProps<{
   disabled?: boolean
   intervals: { again: string; hard: string; good: string; easy: string }
 }>()

--- a/app/components/flashcard/Card.vue
+++ b/app/components/flashcard/Card.vue
@@ -1,28 +1,41 @@
 <template>
-  <div
-    class="w-full max-w-lg mx-auto cursor-pointer select-none"
-    @click="$emit('flip')"
-    role="button"
-    :aria-label="flipped ? 'Verso do card' : 'Toque para ver a resposta'"
-  >
-    <div class="relative" style="perspective: 1000px">
-      <Transition name="flip" mode="out-in">
-        <div
-          :key="flipped ? 'back' : 'front'"
-          class="bg-surface-secondary rounded-2xl p-8 min-h-[250px] flex flex-col items-center justify-center text-center"
-        >
-          <p v-if="!flipped" class="text-label mb-3">{{ deckName }}</p>
-          <div class="text-xl font-medium text-base-primary leading-relaxed card-content" v-html="flipped ? card.back : card.front" />
-          <div v-if="currentAudio" class="mt-4 w-full max-w-xs" @click.stop>
-            <UiAudioPlayer :src="currentAudio" />
-          </div>
-        </div>
-      </Transition>
-    </div>
+  <div class="w-full max-w-2xl mx-auto relative">
+    <!-- Main card -->
+    <Transition name="card-slide" mode="out-in">
+      <div
+        :key="card.id"
+        class="review-card relative rounded-2xl px-12 py-12 min-h-[360px] flex flex-col items-center justify-center text-center"
+        :class="[feedbackClass, { 'cursor-pointer select-none': !flipped }]"
+        style="z-index: 1;"
+        @click="!flipped && $emit('flip')"
+        role="button"
+        :aria-label="flipped ? 'Verso do card' : 'Toque para ver a resposta'"
+      >
+        <!-- Deck label -->
+        <p class="text-[11px] uppercase tracking-[0.08em] text-base-muted opacity-50 mb-4">{{ deckName }}</p>
 
-    <p v-if="!flipped" class="text-base-muted text-micro text-center mt-4">
-      ● Toque no card para ver a resposta
-    </p>
+        <!-- Question (always visible) -->
+        <div
+          class="text-xl leading-relaxed max-w-md card-content"
+          :class="flipped ? 'mb-6 font-medium text-base-primary' : 'font-display text-[1.35rem] text-base-primary'"
+          v-html="card.front"
+        />
+
+        <!-- Divider + Answer (expand reveal) -->
+        <Transition name="answer-expand">
+          <div v-if="flipped" class="w-full max-w-md">
+            <div class="w-12 h-px bg-base-muted/30 mx-auto mb-6" />
+            <div class="text-lg text-[#E5DED1] leading-relaxed card-content" v-html="card.back" />
+            <div v-if="currentAudio" class="mt-4 w-full max-w-xs mx-auto" @click.stop>
+              <UiAudioPlayer :src="currentAudio" />
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+
+    <!-- Tap hint -->
+    <!-- Tap hint removed — user already knows -->
   </div>
 </template>
 
@@ -33,11 +46,16 @@ const props = defineProps<{
   card: Flashcard
   flipped: boolean
   deckName?: string
+  feedback?: 'success' | 'error' | null
 }>()
 
-defineEmits<{
-  flip: []
-}>()
+defineEmits<{ flip: [] }>()
+
+const feedbackClass = computed(() => {
+  if (props.feedback === 'success') return 'feedback-success'
+  if (props.feedback === 'error') return 'feedback-error'
+  return ''
+})
 
 const currentAudio = computed(() =>
   props.flipped ? props.card.back_audio_url : props.card.front_audio_url,
@@ -45,17 +63,77 @@ const currentAudio = computed(() =>
 </script>
 
 <style scoped>
-.flip-enter-active,
-.flip-leave-active {
-  transition: all 150ms ease-in-out;
+.review-card {
+  background: rgba(22, 20, 18, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(217, 119, 6, 0.12);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 20px 60px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(217, 119, 6, 0.05);
+  transition: box-shadow 0.3s ease, border-color 0.3s ease;
 }
-.flip-enter-from {
-  opacity: 0;
-  transform: rotateX(10deg);
+
+:where(.dark) .review-card {
+  background: rgba(16, 14, 12, 0.85);
 }
-.flip-leave-to {
+
+/* Micro feedback — green glow on success */
+.feedback-success {
+  border-color: rgba(34, 197, 94, 0.4);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 20px 60px rgba(0, 0, 0, 0.5),
+    0 0 40px rgba(34, 197, 94, 0.15);
+  animation: settle 0.3s ease;
+}
+
+/* Micro feedback — red glow + shake on error */
+.feedback-error {
+  border-color: rgba(239, 68, 68, 0.4);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 20px 60px rgba(0, 0, 0, 0.5),
+    0 0 40px rgba(239, 68, 68, 0.15);
+  animation: shake 0.3s ease;
+}
+
+@keyframes settle {
+  0% { transform: scale(1); }
+  50% { transform: scale(0.98); }
+  100% { transform: scale(1); }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  75% { transform: translateX(4px); }
+}
+
+/* Card slide out (next card) */
+.card-slide-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.card-slide-leave-to {
   opacity: 0;
-  transform: rotateX(-10deg);
+  transform: translateX(-40px);
+}
+.card-slide-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.card-slide-enter-from {
+  opacity: 0;
+  transform: translateX(40px);
+}
+
+/* Answer expand reveal */
+.answer-expand-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease, max-height 0.3s ease;
+}
+.answer-expand-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
 }
 
 .card-content p { margin: 0.25em 0; display: inline; }

--- a/app/components/flashcard/ErrorDiary.vue
+++ b/app/components/flashcard/ErrorDiary.vue
@@ -2,7 +2,8 @@
   <Transition name="slide-up">
     <div v-if="visible" class="w-full max-w-lg mx-auto">
       <div class="card border border-warning/30 p-4">
-        <p class="text-small text-base-primary font-medium mb-3">Por que você errou?</p>
+        <p class="text-small text-base-primary font-medium mb-1">Por que você errou?</p>
+        <p class="text-micro text-base-muted mb-3">Selecione um motivo para salvar.</p>
 
         <div class="flex flex-wrap gap-2 mb-3">
           <button

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -9,8 +9,8 @@
         v-for="item in items"
         :key="item.to"
         :to="item.to"
-        class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-small text-base-secondary transition-all duration-150"
-        :class="isActive(item.to) ? 'bg-accent-primary-subtle text-accent-primary font-medium' : 'hover:bg-surface-tertiary'"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-small transition-all duration-150"
+        :class="isActive(item.to) ? 'bg-[rgba(217,119,6,0.12)] text-accent-primary font-medium shadow-[inset_2px_0_0_#D97706]' : 'text-base-muted opacity-70 hover:opacity-100 hover:text-base-secondary hover:bg-surface-tertiary'"
         :aria-current="isActive(item.to) ? 'page' : undefined"
       >
         <component :is="getIcon(item.icon)" :size="20" :stroke-width="1.5" />

--- a/app/composables/useGraph.ts
+++ b/app/composables/useGraph.ts
@@ -22,10 +22,10 @@ function nodeRadius(d: D3Node): number {
 }
 
 function nodeColor(d: D3Node): string {
-  if (d.flashcards_count === 0) return '#6B7280' // gray
-  if (d.progress < 0.3) return '#EF4444' // red
-  if (d.progress < 0.7) return '#F59E0B' // amber
-  return '#22C55E' // green
+  if (d.flashcards_count === 0) return '#706B64' // warm muted
+  if (d.progress < 0.3) return '#EF4444' // red danger
+  if (d.progress < 0.7) return '#D97706' // amber active
+  return '#22C55E' // green mastered
 }
 
 function hasWeakConnection(nodeId: string, d3Nodes: D3Node[], d3Links: D3Link[]): boolean {

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -2,9 +2,9 @@
   <div class="p-6 max-w-5xl mx-auto">
     <!-- Greeting -->
     <h1 class="text-display">
-      {{ greeting }}, <span class="text-accent-primary">{{ auth.user?.name?.split(' ')[0] ?? 'estudante' }}</span>
+      {{ greeting }}, <span class="text-accent-primary opacity-85">{{ auth.user?.name?.split(' ')[0] ?? 'estudante' }}</span>
     </h1>
-    <p class="text-base-secondary mt-1">Vamos manter seu ritmo hoje.</p>
+    <p class="text-base-muted mt-1">Vamos manter seu ritmo hoje.</p>
 
     <!-- Retention suggestion banner -->
     <div v-if="retentionSuggestion?.has_suggestion" class="mt-4 p-4 rounded-xl bg-warning/10 border border-warning/30 flex items-start gap-3">
@@ -18,8 +18,17 @@
       </div>
     </div>
 
+    <!-- Survival mode active -->
+    <div v-if="survivalActive" class="mt-4 p-4 rounded-xl bg-warning/10 border border-warning/30 flex items-center gap-3">
+      <ShieldAlert :size="20" class="text-warning shrink-0" />
+      <div class="flex-1">
+        <p class="text-small text-base-primary">🆘 Modo Sobrevivência ativo — apenas os 20 cards mais urgentes serão mostrados.</p>
+      </div>
+      <button class="btn-secondary !py-1 !px-3 !min-h-0 !text-micro" @click="toggleSurvivalMode(false)">Desativar</button>
+    </div>
+
     <!-- Survival mode suggestion -->
-    <div v-if="backlog?.suggest_survival_mode" class="mt-4 p-4 rounded-xl bg-danger/10 border border-danger/30 flex items-center gap-3">
+    <div v-else-if="backlog?.suggest_survival_mode" class="mt-4 p-4 rounded-xl bg-danger/10 border border-danger/30 flex items-center gap-3">
       <ShieldAlert :size="20" class="text-danger shrink-0" />
       <div class="flex-1">
         <p class="text-small text-base-primary">Backlog grande ({{ backlog.overdue_count }} cards)? Ative o Modo Sobrevivência — só os 20 mais urgentes.</p>
@@ -27,23 +36,23 @@
       <button class="btn-primary !py-1 !px-3 !min-h-0 !text-micro" @click="toggleSurvivalMode(true)">Ativar</button>
     </div>
 
-    <!-- Backlog bar -->
-    <div v-if="backlog && backlog.overdue_count > 0" class="card mt-6 flex items-center gap-4">
+    <!-- Backlog bar — herói do dashboard -->
+    <div v-if="backlog && backlog.overdue_count > 0" class="card-warm mt-6 py-5 px-5 flex items-center gap-5" style="background: linear-gradient(90deg, rgba(217,119,6,0.06), transparent);">
       <div class="flex-1">
-        <div class="flex items-center justify-between mb-1">
-          <p class="text-small text-base-primary font-medium">Dívida de revisão</p>
-          <span class="text-micro text-base-muted">~{{ backlog.estimated_minutes }} min para zerar</span>
+        <div class="flex items-center justify-between mb-2">
+          <p class="text-title text-base-primary">Dívida de revisão</p>
+          <span class="text-small text-base-muted">~{{ backlog.estimated_minutes }} min para zerar</span>
         </div>
-        <div class="h-2 rounded-full bg-surface-tertiary">
+        <div class="h-3 rounded-full bg-surface-tertiary overflow-hidden">
           <div
-            class="h-2 rounded-full transition-all"
-            :class="backlog.overdue_count > 50 ? 'bg-danger' : backlog.overdue_count > 10 ? 'bg-warning' : 'bg-success'"
+            class="h-3 rounded-full transition-all duration-500 ease-out"
+            :class="backlog.overdue_count > 50 ? 'bg-danger' : backlog.overdue_count > 10 ? 'bg-warning' : 'bg-success glow-success'"
             :style="{ width: Math.min(100, backlog.overdue_count) + '%' }"
           />
         </div>
-        <p class="text-micro text-base-muted mt-1">{{ backlog.overdue_count }} cards atrasados · {{ backlog.reviews_done_today }} reviews hoje</p>
+        <p class="text-small text-base-muted mt-2">{{ backlog.overdue_count }} cards atrasados · {{ backlog.reviews_done_today }} reviews hoje</p>
       </div>
-      <NuxtLink to="/review" class="btn-primary !py-1.5 !px-3 !min-h-0 !text-small shrink-0">Revisar backlog</NuxtLink>
+      <NuxtLink to="/review?backlog=1" class="btn-primary shrink-0">Revisar agora</NuxtLink>
     </div>
 
     <!-- Progress + Streak -->
@@ -52,38 +61,38 @@
       <div class="card md:col-span-2 flex flex-col gap-4">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-title">Progresso de hoje</p>
-            <p class="text-base-secondary text-small mt-0.5">
-              {{ stats?.reviewed_today ?? 0 }} de {{ totalDue }} revisões completadas
+            <p class="text-title">Seu ritmo hoje</p>
+            <p class="text-base-muted text-small mt-0.5">
+              {{ stats?.reviews_done ?? 0 }}/{{ stats?.reviews_limit ?? '∞' }} reviews · {{ stats?.new_done ?? 0 }}/{{ stats?.new_limit ?? '∞' }} novos
             </p>
           </div>
           <span class="badge badge-primary">Meta diária</span>
         </div>
 
         <!-- Progress bar -->
-        <div class="w-full h-2 rounded-full bg-surface-tertiary">
+        <div class="w-full h-3 rounded-full bg-surface-tertiary overflow-hidden">
           <div
-            class="h-2 rounded-full bg-primary-500 transition-all duration-300"
+            class="h-3 rounded-full bg-success transition-all duration-500 ease-out glow-success"
             :style="{ width: progressPercent + '%' }"
           />
         </div>
 
         <div class="flex justify-between text-micro text-base-muted">
-          <span>● Pendentes: {{ stats?.due_today ?? 0 }}</span>
-          <span>● Revisados: {{ stats?.reviewed_today ?? 0 }}</span>
+          <span>Ainda faltam: {{ stats?.due_today ?? 0 }}</span>
+          <span>Revisados: {{ stats?.reviewed_today ?? 0 }}</span>
         </div>
       </div>
 
       <!-- Streak card -->
       <div class="card flex flex-col items-center justify-center text-center">
         <p class="text-label">Streak atual</p>
-        <p class="text-4xl font-bold text-base-primary mt-2">{{ stats?.streak ?? 0 }}</p>
-        <p class="text-base-secondary text-small mt-1">dias 🔥</p>
+        <p class="text-[2.5rem] font-semibold text-accent-primary mt-2 leading-none">{{ stats?.streak ?? 0 }}</p>
+        <p class="text-base-muted text-small mt-2">dias 🔥</p>
       </div>
     </div>
 
     <!-- Quick actions -->
-    <p class="text-label mt-10 mb-3">Ações rápidas</p>
+    <p class="text-label mt-12 mb-4">Ações rápidas</p>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
       <NuxtLink to="/review" class="btn-primary glow-primary justify-center">
         <Play :size="18" /> Revisar agora
@@ -100,7 +109,7 @@
     </div>
 
     <!-- Decks -->
-    <div class="flex items-center justify-between mt-10 mb-4">
+    <div class="flex items-center justify-between mt-12 mb-4">
       <h2 class="text-headline">Seus decks</h2>
       <NuxtLink to="/decks" class="text-small text-accent-primary hover:underline">Ver todos</NuxtLink>
     </div>
@@ -127,7 +136,7 @@
         <p v-if="deck.description" class="text-base-muted text-small">{{ deck.description }}</p>
       </NuxtLink>
 
-      <NuxtLink to="/decks" class="card-interactive flex flex-col items-center justify-center min-h-[120px] border border-dashed border-base">
+      <NuxtLink to="/decks" class="flex flex-col items-center justify-center min-h-[120px] rounded-xl border border-dashed border-[#333] bg-transparent transition-all duration-200 cursor-pointer hover:bg-[#1E1E1E] hover:border-[#D97706]">
         <Plus :size="24" class="text-base-muted" />
         <span class="text-label mt-2">Novo deck</span>
       </NuxtLink>
@@ -139,7 +148,7 @@
     </div>
 
     <!-- Topic progress -->
-    <div v-if="topicProgress.length" class="mt-10">
+    <div v-if="topicProgress.length" class="mt-12">
       <div class="flex items-center justify-between mb-4">
         <h2 class="text-headline">Progresso por tópico</h2>
         <NuxtLink to="/graph" class="text-small text-accent-primary hover:underline">Ver grafo</NuxtLink>
@@ -177,6 +186,7 @@ const stats = ref<Stats | null>(null)
 const topicProgress = ref<TopicProgress[]>([])
 const backlog = ref<BacklogStats | null>(null)
 const retentionSuggestion = ref<any>(null)
+const survivalActive = ref(false)
 const { $api } = useNuxtApp()
 
 const greeting = computed(() => {
@@ -196,17 +206,19 @@ const progressPercent = computed(() => {
 })
 
 async function loadData() {
-  const [statsRes, , progressRes, backlogRes, retRes] = await Promise.all([
+  const [statsRes, , progressRes, backlogRes, retRes, settingsRes] = await Promise.all([
     $api<any>('/stats'),
     deckStore.fetchDecks(),
     $api<any>('/topics/progress'),
     $api<any>('/review/backlog-stats'),
     $api<any>('/review/retention-suggestion').catch(() => ({ data: { has_suggestion: false } })),
+    $api<any>('/settings'),
   ])
   stats.value = statsRes.data
   topicProgress.value = progressRes.data
   backlog.value = backlogRes.data
   retentionSuggestion.value = retRes.data
+  survivalActive.value = settingsRes.data.survival_mode ?? false
 }
 
 async function toggleSurvivalMode(enabled: boolean) {

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -1,21 +1,36 @@
 <template>
-  <div class="min-h-screen flex flex-col bg-surface">
-    <!-- Top bar -->
-    <div class="flex items-center justify-between px-4 py-3 border-b border-base">
-      <NuxtLink to="/dashboard" class="text-small text-base-muted hover:text-accent-primary">
+  <div class="review-bg h-[calc(100vh-56px)] flex flex-col overflow-hidden">
+    <!-- Top bar — minimal -->
+    <div class="flex items-center justify-between px-4 py-3">
+      <NuxtLink to="/dashboard" class="text-small text-base-muted opacity-60 hover:opacity-100 hover:text-accent-primary transition-opacity">
         ← Voltar
       </NuxtLink>
-      <div class="flex items-center gap-3 text-small text-base-secondary">
-        <span v-if="sessionTimer > 0" class="text-micro font-mono" :class="sessionTimer <= 60 ? 'text-danger' : 'text-base-muted'">
-          ⏱ {{ formatTimer(sessionTimer) }}
+      <div class="flex items-center gap-3 text-small text-base-muted">
+        <span v-if="isSurvivalMode" class="px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wide font-medium bg-warning/15 text-warning">Sobrevivência</span>
+        <span v-if="sessionTimer > 0" class="font-mono" :class="sessionTimer <= 60 ? 'text-danger' : ''" aria-live="polite" :aria-label="`${formatTimer(sessionTimer)} restantes`">
+          {{ formatTimer(sessionTimer) }}
         </span>
-        <span>{{ review.reviewed }} / {{ review.total }}</span>
-        <div class="w-32 h-1.5 rounded-full bg-surface-tertiary">
-          <div class="h-1.5 rounded-full bg-primary-500 transition-all duration-300" :style="{ width: review.progress + '%' }" />
-        </div>
+        <span class="font-medium text-base-primary">{{ review.reviewed }} <span class="opacity-40">/ {{ review.total }}</span></span>
+        <span class="text-micro opacity-50">{{ progressLabel }}</span>
       </div>
       <div class="w-12" />
     </div>
+
+    <!-- Progress bar — thin, with pulse on update -->
+    <div class="w-full h-[3px] bg-[rgba(255,255,255,0.06)]">
+      <div
+        class="h-[3px] transition-all duration-500 ease-out"
+        :class="progressPulse ? 'progress-pulse' : ''"
+        :style="{ width: review.progress + '%', background: 'linear-gradient(90deg, #B45309, #D97706, #F59E0B)' }"
+      />
+    </div>
+
+    <!-- Micro reward toast -->
+    <Transition name="reward-pop">
+      <div v-if="rewardMessage" class="fixed top-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-surface-secondary border border-success/20 text-small text-success shadow-lg">
+        {{ rewardMessage }}
+      </div>
+    </Transition>
 
     <!-- Loading -->
     <div v-if="review.loading" class="flex-1 flex items-center justify-center">
@@ -24,10 +39,10 @@
 
     <!-- Finished -->
     <div v-else-if="review.finished && !review.showErrorDiary" class="flex-1 flex flex-col items-center justify-center px-4 text-center">
-      <p class="text-4xl mb-4">🎉</p>
+      <p class="text-5xl mb-6">🎉</p>
       <h2 class="text-display">Sessão concluída!</h2>
-      <p class="text-base-secondary mt-2">
-        Você revisou {{ review.reviewed }} card{{ review.reviewed !== 1 ? 's' : '' }}.
+      <p class="text-base-muted mt-3">
+        Você revisou <span class="text-accent-primary font-medium">{{ review.reviewed }}</span> card{{ review.reviewed !== 1 ? 's' : '' }}.
       </p>
       <p v-if="review.pendingLearning > 0" class="text-base-muted text-small mt-2">
         {{ review.pendingLearning }} card{{ review.pendingLearning !== 1 ? 's' : '' }} em aprendizado — {{ review.pendingLearning === 1 ? 'volta' : 'voltam' }} em breve.
@@ -46,20 +61,25 @@
     </div>
 
     <!-- Review -->
-    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 gap-8">
-      <!-- Learning badge -->
-      <div v-if="review.currentCard.is_learning" class="flex items-center gap-2">
+    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 gap-10">
+      <!-- State badge -->
+      <div v-if="review.currentCard.is_learning || review.currentCard.state === 'new'" class="flex items-center gap-2">
         <span
-          class="px-3 py-1 rounded-full text-micro font-medium"
-          :class="review.currentCard.state === 'relearning' ? 'bg-orange-500/20 text-orange-400' : 'bg-blue-500/20 text-blue-400'"
+          class="px-3 py-1 rounded-full text-[11px] tracking-wide uppercase font-medium"
+          :class="{
+            'bg-orange-500/15 text-orange-400': review.currentCard.state === 'relearning',
+            'bg-blue-500/15 text-blue-400': review.currentCard.state === 'learning',
+            'bg-emerald-500/15 text-emerald-400': review.currentCard.state === 'new',
+          }"
         >
-          {{ review.currentCard.state === 'relearning' ? '🔄 Reaprendendo' : '📖 Aprendendo' }}
+          {{ review.currentCard.state === 'relearning' ? '🔄 Reaprendendo' : review.currentCard.state === 'new' ? '✨ Novo' : '📖 Aprendendo' }}
         </span>
       </div>
 
       <FlashcardCard
         :card="review.currentCard"
         :flipped="review.flipped"
+        :feedback="cardFeedback"
         @flip="review.flip()"
       />
 
@@ -73,7 +93,7 @@
       <!-- Weak connection suggestion -->
       <div v-if="review.weakSuggestion?.length && !review.showErrorDiary" class="w-full max-w-lg px-4">
         <div class="card border border-warning/30 text-center">
-          <p class="text-small text-base-secondary mb-2">Tópico conectado também está fraco:</p>
+          <p class="text-small text-base-muted mb-2">Tópico conectado também está fraco:</p>
           <div v-for="w in review.weakSuggestion" :key="w.id" class="flex items-center justify-center gap-2 text-small">
             <span class="text-warning">⚠</span>
             <span class="text-base-primary font-medium">{{ w.name }}</span>
@@ -90,7 +110,7 @@
       <NuxtLink to="/dashboard" class="btn-primary mt-6">Voltar ao dashboard</NuxtLink>
     </div>
 
-    <!-- Error diary (outside card flow so it persists after card advances) -->
+    <!-- Error diary -->
     <div v-if="review.showErrorDiary" class="flex-1 flex flex-col items-center justify-center px-4">
       <FlashcardErrorDiary
         :visible="true"
@@ -111,6 +131,20 @@
         </NuxtLink>
       </div>
     </div>
+    <!-- Timer expired modal -->
+    <UiModal v-model="showTimerModal" size="sm" aria-label="Tempo esgotado">
+      <div class="text-center">
+        <p class="text-4xl mb-4">⏰</p>
+        <h2 class="text-title font-serif">Tempo esgotado!</h2>
+        <p class="text-base-muted text-small mt-2">
+          Você revisou <span class="text-accent-primary font-medium">{{ review.reviewed }}</span> card{{ review.reviewed !== 1 ? 's' : '' }}.
+        </p>
+        <div class="flex gap-3 mt-6 justify-center">
+          <NuxtLink to="/dashboard" class="btn-secondary">Encerrar</NuxtLink>
+          <button class="btn-primary" @click="continueAfterTimer">Continuar</button>
+        </div>
+      </div>
+    </UiModal>
   </div>
 </template>
 
@@ -120,9 +154,38 @@ const deckStore = useDeckStore()
 const route = useRoute()
 const toast = useToast()
 const lastErrorCardId = ref('')
+const cardFeedback = ref<'success' | 'error' | null>(null)
+const correctStreak = ref(0)
+const rewardMessage = ref('')
+const progressPulse = ref(false)
+let rewardTimeout: ReturnType<typeof setTimeout> | null = null
 
 async function handleRate(rating: number) {
   const cardId = review.currentCard?.id ?? ''
+
+  // Micro feedback
+  cardFeedback.value = rating >= 3 ? 'success' : 'error'
+
+  // Track streak
+  if (rating >= 3) {
+    correctStreak.value++
+    // Micro reward at milestones
+    if (correctStreak.value === 3) showReward('🔥 3 seguidos!')
+    else if (correctStreak.value === 5) showReward('⚡ 5 seguidos — bom ritmo!')
+    else if (correctStreak.value === 10) showReward('🧠 10 seguidos — você tá voando!')
+    else if (correctStreak.value > 0 && correctStreak.value % 10 === 0) showReward(`🔥 ${correctStreak.value} seguidos!`)
+  } else {
+    correctStreak.value = 0
+  }
+
+  // Progress pulse
+  progressPulse.value = true
+  setTimeout(() => { progressPulse.value = false }, 600)
+
+  // Let feedback show briefly before advancing
+  await new Promise(r => setTimeout(r, 450))
+  cardFeedback.value = null
+
   try {
     await review.submitReview(rating as 1 | 2 | 3 | 4)
     if (rating === 1) {
@@ -140,31 +203,43 @@ async function loadSession() {
   const deckId = route.query.deck_id as string | undefined
   const topicId = route.query.topic_id as string | undefined
   const errorsOnly = route.query.errors_only === '1'
+  const backlog = route.query.backlog === '1'
   if (deckId) await deckStore.fetchDeck(deckId)
-  await review.fetchSession(deckId, topicId, errorsOnly)
+  await review.fetchSession(deckId, topicId, errorsOnly, backlog)
   await loadSessionTimer()
 }
 
-// Session timer
+// Session timer & survival mode
 const sessionTimer = ref(0)
+const showTimerModal = ref(false)
+const isSurvivalMode = ref(false)
 let timerInterval: ReturnType<typeof setInterval> | null = null
-const showTimeUp = ref(false)
 
 async function loadSessionTimer() {
   try {
     const { $api } = useNuxtApp()
     const res = await $api<any>('/settings')
+    isSurvivalMode.value = res.data.survival_mode ?? false
     const limit = res.data.session_time_limit
     if (limit) {
       sessionTimer.value = limit * 60
       timerInterval = setInterval(() => {
-        if (sessionTimer.value > 0) {
-          sessionTimer.value--
-          if (sessionTimer.value === 0) showTimeUp.value = true
-        }
+        if (sessionTimer.value > 0) sessionTimer.value--
       }, 1000)
     }
   } catch {}
+}
+
+watch(sessionTimer, (val, oldVal) => {
+  if (val === 0 && oldVal > 0) {
+    if (timerInterval) clearInterval(timerInterval)
+    timerInterval = null
+    showTimerModal.value = true
+  }
+})
+
+function continueAfterTimer() {
+  showTimerModal.value = false
 }
 
 function formatTimer(seconds: number): string {
@@ -172,6 +247,21 @@ function formatTimer(seconds: number): string {
   const s = seconds % 60
   return `${m}:${s.toString().padStart(2, '0')}`
 }
+
+function showReward(msg: string) {
+  rewardMessage.value = msg
+  if (rewardTimeout) clearTimeout(rewardTimeout)
+  rewardTimeout = setTimeout(() => { rewardMessage.value = '' }, 1800)
+}
+
+const progressLabel = computed(() => {
+  const pct = review.progress
+  if (pct === 0) return 'começando'
+  if (pct < 25) return 'aquecendo'
+  if (pct < 70) return 'no ritmo'
+  if (pct < 100) return 'quase lá'
+  return 'concluído'
+})
 
 onMounted(loadSession)
 
@@ -185,9 +275,43 @@ onMounted(() => {
 onUnmounted(() => {
   if (tickInterval) clearInterval(tickInterval)
   if (timerInterval) clearInterval(timerInterval)
+  if (rewardTimeout) clearTimeout(rewardTimeout)
 })
 
 watch(() => route.query, (newQ, oldQ) => {
   if (JSON.stringify(newQ) !== JSON.stringify(oldQ)) loadSession()
 })
 </script>
+
+<style scoped>
+.review-bg {
+  background: radial-gradient(ellipse at 50% 45%, #1E1814 0%, #110F0D 40%, #0A0908 70%);
+  color: var(--text-primary);
+}
+
+.progress-pulse {
+  box-shadow: 0 0 8px rgba(217, 119, 6, 0.3);
+  animation: pulse-glow 0.6s ease;
+}
+
+@keyframes pulse-glow {
+  0% { box-shadow: 0 0 4px rgba(217, 119, 6, 0.1); }
+  50% { box-shadow: 0 0 12px rgba(217, 119, 6, 0.4); }
+  100% { box-shadow: 0 0 4px rgba(217, 119, 6, 0.1); }
+}
+
+.reward-pop-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.reward-pop-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+.reward-pop-enter-from {
+  opacity: 0;
+  transform: translate(-50%, -8px) scale(0.95);
+}
+.reward-pop-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -4px);
+}
+</style>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-6 max-w-2xl mx-auto">
+  <div class="p-6 max-w-5xl mx-auto">
     <h1 class="text-display mb-8">Configurações</h1>
 
     <!-- Perfil -->
@@ -51,40 +51,55 @@
     </section>
 
     <!-- Sessão de Estudo -->
-    <section class="card p-5 mb-6">
-      <h2 class="text-headline mb-1">Sessão de Estudo</h2>
-      <p class="text-micro text-base-muted mb-4">Controle a carga diária de revisão para evitar sobrecarga.</p>
+    <section class="card p-6 md:p-8 mb-6">
+      <h2 class="text-headline mb-2">Sessão de Estudo</h2>
+      <p class="text-small text-base-muted mb-8">Configure quanto você quer estudar por dia. O app nunca descarta cards — o que não couber hoje aparece amanhã.</p>
 
-      <div class="space-y-4">
-        <div>
-          <div class="flex items-center justify-between mb-1">
-            <label class="text-label">Novos cards por dia</label>
-            <label class="flex items-center gap-1.5 text-micro text-base-muted cursor-pointer">
-              <input type="checkbox" :checked="settings.daily_new_cards_limit === null" @change="settings.daily_new_cards_limit = ($event.target as HTMLInputElement).checked ? null : 20" class="accent-[#522A6F]" />
+      <div class="space-y-8">
+        <div class="card p-5">
+          <div class="flex items-center justify-between mb-3">
+            <label class="text-title">Novos cards por dia</label>
+            <label class="flex items-center gap-2 text-small text-base-muted cursor-pointer">
+              <input type="checkbox" :checked="settings.daily_new_cards_limit === null" @change="settings.daily_new_cards_limit = ($event.target as HTMLInputElement).checked ? null : 20" class="accent-[#D97706]" />
               Ilimitado
             </label>
           </div>
-          <input v-if="settings.daily_new_cards_limit !== null" v-model.number="settings.daily_new_cards_limit" type="number" min="1" max="999" class="input-base w-32" />
-          <p class="text-micro text-base-muted mt-1">Cada novo card gera ~7-10 revisões no mês seguinte.</p>
+          <input v-if="settings.daily_new_cards_limit !== null" v-model.number="settings.daily_new_cards_limit" type="number" min="1" max="999" class="input-base w-32 mb-4" />
+          <div class="text-small text-base-muted leading-relaxed space-y-2">
+            <p>Controla quantos cards <strong class="text-base-secondary">que você nunca estudou</strong> vão aparecer por dia. Se você colocar 5, o app vai te mostrar no máximo 5 cards totalmente novos — o resto fica guardado pra depois.</p>
+            <p class="text-warning">⚠️ Cada card novo gera cerca de 7 revisões nas semanas seguintes. Se colocar 20 novos/dia, em um mês você terá ~150 revisões diárias.</p>
+            <p>💡 Recomendado: comece com <strong class="text-base-secondary">5</strong> e aumente conforme se sentir confortável.</p>
+          </div>
         </div>
 
-        <div>
-          <div class="flex items-center justify-between mb-1">
-            <label class="text-label">Máximo de revisões por dia</label>
-            <label class="flex items-center gap-1.5 text-micro text-base-muted cursor-pointer">
-              <input type="checkbox" :checked="settings.daily_review_limit === null" @change="settings.daily_review_limit = ($event.target as HTMLInputElement).checked ? null : 100" class="accent-[#522A6F]" />
+        <div class="card p-5">
+          <div class="flex items-center justify-between mb-3">
+            <label class="text-title">Máximo de revisões por dia</label>
+            <label class="flex items-center gap-2 text-small text-base-muted cursor-pointer">
+              <input type="checkbox" :checked="settings.daily_review_limit === null" @change="settings.daily_review_limit = ($event.target as HTMLInputElement).checked ? null : 100" class="accent-[#D97706]" />
               Ilimitado
             </label>
           </div>
-          <input v-if="settings.daily_review_limit !== null" v-model.number="settings.daily_review_limit" type="number" min="1" max="9999" class="input-base w-32" />
+          <input v-if="settings.daily_review_limit !== null" v-model.number="settings.daily_review_limit" type="number" min="1" max="9999" class="input-base w-32 mb-4" />
+          <div class="text-small text-base-muted leading-relaxed space-y-2">
+            <p>O <strong class="text-base-secondary">total de cards</strong> que você vai estudar no dia — inclui novos e revisões de cards antigos.</p>
+            <p>Exemplo: se você colocar 30, o app vai te mostrar no máximo 30 cards por dia, mesmo que tenha 100 pendentes. Os que sobrarem aparecem nos dias seguintes.</p>
+            <p>💡 Pouco tempo? Coloque <strong class="text-base-secondary">20–30</strong> (~10 min de estudo). Quer estudar bastante? Deixe ilimitado.</p>
+          </div>
         </div>
 
-        <div>
-          <label class="text-label mb-1 block">Limite de tempo por sessão</label>
-          <UiSelect v-model="sessionTimeStr" :options="timeOptions" placeholder="Sem limite" />
+        <div class="card p-5">
+          <label class="text-title mb-3 block">Limite de tempo por sessão</label>
+          <div class="mb-4">
+            <UiSelect v-model="sessionTimeStr" :options="timeOptions" placeholder="Sem limite" />
+          </div>
+          <div class="text-small text-base-muted leading-relaxed space-y-2">
+            <p>Define um cronômetro para sua sessão de estudo. Quando o tempo acabar, o app te avisa — mas não interrompe no meio de um card. Você escolhe se quer continuar ou parar.</p>
+            <p>💡 Útil pra quem estuda no ônibus, no intervalo do trabalho, ou quer sessões curtas e focadas.</p>
+          </div>
         </div>
 
-        <button class="btn-primary !py-1.5 !px-4 !min-h-0 !text-small" :disabled="savingSettings" @click="saveSettings">
+        <button class="btn-primary" :disabled="savingSettings" @click="saveSettings">
           {{ savingSettings ? 'Salvando...' : 'Salvar configurações' }}
         </button>
       </div>

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -32,17 +32,20 @@ export const useReviewStore = defineStore('review', {
     currentIntervals(): { again: string; hard: string; good: string; easy: string } {
       return this.currentCard?.next_intervals ?? { again: '', hard: '', good: '', easy: '' }
     },
-    total: (state) => state.cards.length,
+    total(state): number {
+      return state.cards.length + state.learningQueue.length
+    },
     reviewed: (state) => state.currentIndex,
     progress(state): number {
-      if (!state.cards.length) return 0
-      return Math.round((state.currentIndex / state.cards.length) * 100)
+      const t = state.cards.length + state.learningQueue.length
+      if (!t) return 0
+      return Math.min(100, Math.round((state.currentIndex / t) * 100))
     },
     pendingLearning: (state) => state.learningQueue.length,
   },
 
   actions: {
-    async fetchSession(deckId?: string, topicId?: string, errorsOnly?: boolean) {
+    async fetchSession(deckId?: string, topicId?: string, errorsOnly?: boolean, backlog?: boolean) {
       this.loading = true
       this.finished = false
       this.currentIndex = 0
@@ -57,10 +60,25 @@ export const useReviewStore = defineStore('review', {
         if (deckId) params.set('deck_id', deckId)
         if (topicId) params.set('topic_id', topicId)
         if (errorsOnly) params.set('errors_only', '1')
+        if (backlog) params.set('backlog', '1')
         const query = params.toString() ? `?${params}` : ''
         const res = await $api<any>(`/review/session${query}`)
-        this.cards = res.data
-        if (!this.cards.length) this.finished = true
+        const allCards = res.data as SessionCard[]
+        const now = Date.now()
+
+        // Separate learning/relearning cards with future due into learningQueue
+        this.cards = []
+        for (const card of allCards) {
+          const isLearning = card.state === 'learning' || card.state === 'relearning'
+          const dueFuture = card.due && new Date(card.due).getTime() > now
+          if (isLearning && dueFuture) {
+            this.learningQueue.push({ card, dueAt: new Date(card.due!).getTime() })
+          } else {
+            this.cards.push(card)
+          }
+        }
+
+        if (!this.cards.length && !this.learningQueue.length) this.finished = true
       } finally {
         this.loading = false
       }
@@ -112,9 +130,10 @@ export const useReviewStore = defineStore('review', {
 
         // Learn ahead: if no more main cards, show all learning cards immediately
         if (!hasMoreMainCards) {
-          for (const item of this.learningQueue) {
-            item.dueAt = Date.now()
-          }
+          this.learningQueue = this.learningQueue.map(item => ({
+            ...item,
+            dueAt: Date.now(),
+          }))
         }
 
         this.flipped = false

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -56,7 +56,7 @@ export default defineNuxtConfig({
         { rel: 'apple-touch-icon', href: '/apple-touch-icon.svg' },
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
-        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Manrope:wght@600;700;800&display=swap' },
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600&family=Manrope:wght@600;700;800&display=swap' },
       ],
     },
   },


### PR DESCRIPTION
Closes #30

## Redesign UI — Paleta "High-Tech Earthy"
- Paleta amber queimado (#D97706) como identidade
- Fonte DM Serif Display nos headlines
- Dashboard, revisão e settings redesenhados

## Correções Fase 2.9
- Timer de sessão: modal "Tempo esgotado" ao expirar
- Banner "Modo Sobrevivência ativo" com botão Desativar
- Badge "Sobrevivência" no header da sessão
- Badge "✨ Novo" nos cards com state=new
- Barra de progresso inclui learningQueue no total
- Fix reatividade learn ahead (novo array em vez de mutação in-place)
- Dashboard: reviews e novos separados ("10/10 reviews · 3/3 novos")
- Botão da barra de dívida passa `?backlog=1` (ignora limites)
- Estilo disabled no btn-primary
- Instrução "Selecione um motivo" no ErrorDiary