### PR TITLE
feat(flashcard): importar Anki — frontend + cloze rendering

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -643,3 +643,19 @@ button {
   background-color: rgba(217, 119, 6, 0.3);
   color: #E9E4D9;
 }
+
+/* Cloze deletion styles */
+.cloze-blank {
+  display: inline;
+  padding: 0.1em 0.6em;
+  border-radius: 0.25rem;
+  background: rgba(217, 119, 6, 0.15);
+  border-bottom: 2px solid rgba(217, 119, 6, 0.4);
+  color: rgba(217, 119, 6, 0.7);
+  font-style: italic;
+}
+
+.cloze-answer {
+  color: #D97706;
+  font-weight: 600;
+}

--- a/app/components/flashcard/Card.vue
+++ b/app/components/flashcard/Card.vue
@@ -18,14 +18,18 @@
         <div
           class="text-xl leading-relaxed max-w-md card-content"
           :class="flipped ? 'mb-6 font-medium text-base-primary' : 'font-display text-[1.35rem] text-base-primary'"
-          v-html="card.front"
+          v-html="displayFront"
         />
 
         <!-- Divider + Answer (expand reveal) -->
         <Transition name="answer-expand">
           <div v-if="flipped" class="w-full max-w-md">
-            <div class="w-12 h-px bg-base-muted/30 mx-auto mb-6" />
-            <div class="text-lg text-[#E5DED1] leading-relaxed card-content" v-html="card.back" />
+            <div class="flex items-center gap-3 mb-6">
+              <div class="flex-1 h-px bg-white/10" />
+              <span class="text-[10px] uppercase tracking-widest text-base-muted/50">Resposta</span>
+              <div class="flex-1 h-px bg-white/10" />
+            </div>
+            <div class="text-lg text-[#E5DED1] leading-relaxed card-content" v-html="displayBack" />
             <div v-if="currentAudio" class="mt-4 w-full max-w-xs mx-auto" @click.stop>
               <UiAudioPlayer :src="currentAudio" />
             </div>
@@ -51,10 +55,30 @@ const props = defineProps<{
 
 defineEmits<{ flip: [] }>()
 
+const { renderQuestion, renderAnswer } = useCloze()
+const config = useRuntimeConfig()
+const apiOrigin = config.public.apiBase.replace('/api', '')
+
+function resolveMedia(html: string): string {
+  return html.replace(/src="\/storage\//g, `src="${apiOrigin}/storage/`)
+}
+
 const feedbackClass = computed(() => {
   if (props.feedback === 'success') return 'feedback-success'
   if (props.feedback === 'error') return 'feedback-error'
   return ''
+})
+
+const isCloze = computed(() => props.card.type === 'cloze')
+
+const displayFront = computed(() => {
+  const html = isCloze.value ? renderQuestion(props.card.front, props.card.cloze_index ?? undefined) : props.card.front
+  return resolveMedia(html)
+})
+
+const displayBack = computed(() => {
+  const html = isCloze.value ? renderAnswer(props.card.front, props.card.cloze_index ?? undefined) : props.card.back
+  return resolveMedia(html)
 })
 
 const currentAudio = computed(() =>
@@ -137,4 +161,6 @@ const currentAudio = computed(() =>
 }
 
 .card-content p { margin: 0.25em 0; display: inline; }
+:deep(.card-content a) { pointer-events: none; color: inherit; text-decoration: none; }
+:deep(.card-content img) { max-width: 100%; height: auto; border-radius: 0.5rem; margin: 0.5rem 0; }
 </style>

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -47,6 +47,7 @@ import {
   Network,
   Settings,
   LogOut,
+  Upload,
 } from 'lucide-vue-next'
 
 const route = useRoute()
@@ -68,6 +69,7 @@ const items = [
   { label: 'Grafo', to: '/graph', icon: 'graph' },
   { label: 'Revisão', to: '/review', icon: 'review' },
   { label: 'Estatísticas', to: '/stats', icon: 'stats' },
+  { label: 'Importar', to: '/import', icon: 'import' },
 ]
 
 const iconMap: Record<string, any> = {
@@ -77,6 +79,7 @@ const iconMap: Record<string, any> = {
   graph: Network,
   review: BookOpen,
   stats: BarChart3,
+  import: Upload,
 }
 
 function getIcon(name: string) {

--- a/app/composables/useCloze.ts
+++ b/app/composables/useCloze.ts
@@ -1,0 +1,28 @@
+const clozePattern = /\{\{c(\d+)::([\s\S]*?)(?:::([\s\S]+?))?\}\}/g
+const wrapperPattern = /\[\[r::([\s\S]+?)\]\]/g
+
+export function useCloze() {
+  function stripWrappers(text: string): string {
+    return text.replace(wrapperPattern, '$1')
+  }
+
+  function renderQuestion(text: string, clozeIndex?: number): string {
+    return stripWrappers(text).replace(clozePattern, (_match, num, _answer, hint) => {
+      if (clozeIndex !== undefined && parseInt(num) !== clozeIndex) {
+        return _answer
+      }
+      return `<span class="cloze-blank">${hint || '...'}</span>`
+    })
+  }
+
+  function renderAnswer(text: string, clozeIndex?: number): string {
+    return stripWrappers(text).replace(clozePattern, (_match, num, answer) => {
+      if (clozeIndex !== undefined && parseInt(num) !== clozeIndex) {
+        return answer
+      }
+      return `<strong class="cloze-answer">${answer}</strong>`
+    })
+  }
+
+  return { renderQuestion, renderAnswer }
+}

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -106,6 +106,9 @@
       <button class="btn-accent justify-center" disabled title="Em breve">
         <Upload :size="18" /> Subir PDF
       </button>
+      <NuxtLink to="/import" class="btn-accent justify-center">
+        <Upload :size="18" /> Importar Anki
+      </NuxtLink>
     </div>
 
     <!-- Decks -->

--- a/app/pages/import.vue
+++ b/app/pages/import.vue
@@ -1,0 +1,250 @@
+<template>
+  <div class="max-w-2xl mx-auto px-4 py-8">
+    <h1 class="text-display mb-6">Importar Anki</h1>
+
+    <!-- Step 1: Upload -->
+    <div v-if="!store.importId" class="card p-8 text-center">
+      <Upload :size="48" class="mx-auto text-base-muted mb-4" />
+      <p class="text-title mb-2">Selecione seu arquivo .apkg</p>
+      <p class="text-small text-base-muted mb-6">Suporta decks exportados do Anki (até 500MB)</p>
+
+      <label
+        class="btn-primary cursor-pointer inline-flex"
+        :class="{ 'opacity-50 pointer-events-none': store.uploading }"
+      >
+        {{ store.uploading ? 'Enviando...' : 'Selecionar arquivo' }}
+        <input type="file" accept=".apkg" class="hidden" @change="handleFile" :disabled="store.uploading">
+      </label>
+
+      <div
+        class="mt-6 border-2 border-dashed border-surface-tertiary rounded-xl p-8 transition-colors"
+        :class="dragOver ? 'border-accent-primary bg-accent-primary/5' : ''"
+        @dragover.prevent="dragOver = true"
+        @dragleave="dragOver = false"
+        @drop.prevent="handleDrop"
+      >
+        <p class="text-small text-base-muted">ou arraste e solte aqui</p>
+      </div>
+    </div>
+
+    <!-- Step 2: Preview -->
+    <div v-else-if="store.preview && (!store.status || store.status.status === 'previewing')" class="space-y-4">
+      <div class="card p-5">
+        <p class="text-title mb-4">Preview da importação</p>
+
+        <!-- Decks -->
+        <div class="mb-4">
+          <p class="text-label mb-2">Decks ({{ store.preview.decks.length }})</p>
+          <div v-for="deck in store.preview.decks" :key="deck.name" class="flex items-center justify-between py-2 border-b border-surface-tertiary last:border-0">
+            <div>
+              <span class="text-small text-base-primary">{{ deck.name }}</span>
+              <span class="text-micro text-base-muted ml-2">{{ deck.cards_count }} cards</span>
+            </div>
+            <div v-if="deck.conflict" class="flex items-center gap-2">
+              <span class="text-micro text-warning">⚠ Já existe</span>
+              <UiSelect
+                :model-value="store.deckConflicts[deck.name]"
+                @update:model-value="store.deckConflicts[deck.name] = $event"
+                :options="[{ value: 'import', label: 'Importar como novo' }, { value: 'skip', label: 'Pular' }]"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- Stats -->
+        <div class="grid grid-cols-3 gap-3 mb-4">
+          <div class="bg-surface-tertiary rounded-lg p-3 text-center">
+            <p class="text-title text-accent-primary">{{ store.preview.total_cards }}</p>
+            <p class="text-micro text-base-muted">Cards</p>
+          </div>
+          <div class="bg-surface-tertiary rounded-lg p-3 text-center">
+            <p class="text-title text-accent-primary">{{ store.preview.tags.length }}</p>
+            <p class="text-micro text-base-muted">Tags → Tópicos</p>
+          </div>
+          <div class="bg-surface-tertiary rounded-lg p-3 text-center">
+            <p class="text-title text-accent-primary">{{ store.preview.media_count }}</p>
+            <p class="text-micro text-base-muted">Media</p>
+          </div>
+        </div>
+
+        <!-- Note types -->
+        <div class="mb-4">
+          <p class="text-label mb-2">Tipos de card</p>
+          <div class="flex gap-3 text-small">
+            <span v-if="store.preview.note_types.Basic" class="px-2 py-1 rounded bg-surface-tertiary">Basic: {{ store.preview.note_types.Basic }}</span>
+            <span v-if="store.preview.note_types.Cloze" class="px-2 py-1 rounded bg-surface-tertiary">Cloze: {{ store.preview.note_types.Cloze }}</span>
+            <span v-if="store.preview.note_types.Other" class="px-2 py-1 rounded bg-surface-tertiary">Outros: {{ store.preview.note_types.Other }}</span>
+          </div>
+        </div>
+
+        <!-- Tags preview -->
+        <div v-if="store.preview.tags.length">
+          <p class="text-label mb-2">Tags encontradas</p>
+          <div class="flex flex-wrap gap-1">
+            <span v-for="tag in store.preview.tags" :key="tag" class="px-2 py-0.5 rounded-full bg-surface-tertiary text-micro text-base-muted">
+              {{ tag }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex gap-3 justify-end">
+        <button class="btn-secondary" @click="cancel">Cancelar</button>
+        <button class="btn-primary" @click="confirmImport">Confirmar importação</button>
+      </div>
+    </div>
+
+    <!-- Step 3: Progress -->
+    <div v-else-if="store.status && (store.status.status === 'processing' || store.status.status === 'confirmed')" class="card p-8 text-center">
+      <div class="animate-pulse text-4xl mb-4">⏳</div>
+      <p class="text-title mb-2">Importando...</p>
+      <p class="text-small text-base-muted mb-4">{{ stepLabel }}</p>
+
+      <div class="w-full h-3 rounded-full bg-surface-tertiary overflow-hidden mb-2">
+        <div
+          class="h-3 rounded-full bg-accent-primary transition-all duration-500"
+          :style="{ width: (store.status.progress_percent ?? 0) + '%' }"
+        />
+      </div>
+      <p class="text-micro text-base-muted">
+        <template v-if="store.status.imported_cards">
+          {{ store.status.imported_cards }}/{{ store.status.total_cards }} cards
+        </template>
+        <template v-else>
+          {{ store.status.progress_percent ?? 0 }}%
+        </template>
+      </p>
+    </div>
+
+    <!-- Step 4: Completed -->
+    <div v-else-if="store.status?.status === 'completed'" class="card p-8 text-center">
+      <p class="text-5xl mb-4">🎉</p>
+      <h2 class="text-display mb-2">Importação concluída!</h2>
+      <div class="grid grid-cols-2 gap-3 max-w-xs mx-auto mt-4 mb-6">
+        <div class="bg-surface-tertiary rounded-lg p-3">
+          <p class="text-title text-accent-primary">{{ store.status.stats?.decks_created }}</p>
+          <p class="text-micro text-base-muted">Decks</p>
+        </div>
+        <div class="bg-surface-tertiary rounded-lg p-3">
+          <p class="text-title text-accent-primary">{{ store.status.stats?.cards_created }}</p>
+          <p class="text-micro text-base-muted">Cards</p>
+        </div>
+        <div class="bg-surface-tertiary rounded-lg p-3">
+          <p class="text-title text-accent-primary">{{ store.status.stats?.topics_created }}</p>
+          <p class="text-micro text-base-muted">Tópicos</p>
+        </div>
+        <div class="bg-surface-tertiary rounded-lg p-3">
+          <p class="text-title text-accent-primary">{{ store.status.stats?.media_extracted }}</p>
+          <p class="text-micro text-base-muted">Media</p>
+        </div>
+      </div>
+      <NuxtLink to="/decks" class="btn-primary">Ver decks</NuxtLink>
+    </div>
+
+    <!-- Failed -->
+    <div v-else-if="store.status?.status === 'failed'" class="card p-8 text-center">
+      <p class="text-4xl mb-4">❌</p>
+      <h2 class="text-display mb-2">Erro na importação</h2>
+      <p class="text-small text-base-muted mb-4">{{ store.status.error }}</p>
+      <button class="btn-primary" @click="retryImport">Tentar novamente</button>
+    </div>
+
+    <!-- Loading -->
+    <div v-else-if="store.loading" class="card p-8 text-center">
+      <div class="skeleton h-48 rounded-xl" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Upload } from 'lucide-vue-next'
+
+const store = useImportStore()
+const toast = useToast()
+const dragOver = ref(false)
+let pollInterval: ReturnType<typeof setInterval> | null = null
+
+const stepLabel = computed(() => {
+  const step = store.status?.current_step
+  const map: Record<string, string> = {
+    creating_decks: 'Criando decks...',
+    creating_topics: 'Criando tópicos...',
+    importing_cards: 'Importando cards...',
+    extracting_media: 'Extraindo media...',
+  }
+  return map[step ?? ''] ?? 'Processando...'
+})
+
+async function handleFile(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) await uploadFile(file)
+}
+
+async function handleDrop(e: DragEvent) {
+  dragOver.value = false
+  const file = e.dataTransfer?.files[0]
+  if (file) await uploadFile(file)
+}
+
+async function uploadFile(file: File) {
+  if (!file.name.endsWith('.apkg')) {
+    toast.show('Selecione um arquivo .apkg válido.', 'error')
+    return
+  }
+  try {
+    await store.upload(file)
+    await store.fetchPreview()
+  } catch {
+    toast.show('Erro ao processar arquivo.', 'error')
+    store.reset()
+  }
+}
+
+async function confirmImport() {
+  try {
+    await store.confirm()
+    startPolling()
+  } catch {
+    toast.show('Erro ao iniciar importação.', 'error')
+  }
+}
+
+function startPolling() {
+  pollInterval = setInterval(async () => {
+    await store.pollStatus()
+    if (store.status?.status === 'completed' || store.status?.status === 'failed') {
+      stopPolling()
+    }
+  }, 2000)
+}
+
+function stopPolling() {
+  if (pollInterval) {
+    clearInterval(pollInterval)
+    pollInterval = null
+  }
+}
+
+async function retryImport() {
+  try {
+    store.status = null
+    await store.confirm()
+    startPolling()
+  } catch {
+    toast.show('Erro ao reprocessar importação.', 'error')
+  }
+}
+
+function cancel() {
+  stopPolling()
+  store.reset()
+}
+
+onMounted(() => {
+  store.reset()
+})
+
+onUnmounted(() => {
+  stopPolling()
+})
+</script>

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="review-bg h-[calc(100vh-56px)] flex flex-col overflow-hidden">
+  <div class="review-bg h-[calc(100vh-56px)] flex flex-col overflow-y-auto">
     <!-- Top bar — minimal -->
     <div class="flex items-center justify-between px-4 py-3">
       <NuxtLink to="/dashboard" class="text-small text-base-muted opacity-60 hover:opacity-100 hover:text-accent-primary transition-opacity">
@@ -33,8 +33,15 @@
     </Transition>
 
     <!-- Loading -->
-    <div v-if="review.loading" class="flex-1 flex items-center justify-center">
-      <div class="skeleton h-64 w-full max-w-lg rounded-2xl" />
+    <div v-if="review.loading" class="flex-1 flex flex-col items-center justify-center px-4 gap-6">
+      <div class="w-full max-w-2xl">
+        <div class="review-card rounded-2xl px-12 py-12 min-h-[360px] flex flex-col items-center justify-center gap-4">
+          <div class="skeleton h-4 w-24 rounded" />
+          <div class="skeleton h-6 w-64 rounded mt-4" />
+          <div class="skeleton h-4 w-48 rounded" />
+        </div>
+      </div>
+      <p class="text-small text-base-muted animate-pulse">Carregando sessão...</p>
     </div>
 
     <!-- Finished -->
@@ -61,7 +68,7 @@
     </div>
 
     <!-- Review -->
-    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 gap-10">
+    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 pt-6 gap-10">
       <!-- State badge -->
       <div v-if="review.currentCard.is_learning || review.currentCard.state === 'new'" class="flex items-center gap-2">
         <span
@@ -85,6 +92,7 @@
 
       <FlashcardButtons
         v-if="review.flipped"
+        class="sticky bottom-4 z-10"
         :disabled="review.submitting"
         :intervals="review.currentIntervals"
         @rate="handleRate"

--- a/app/stores/import.ts
+++ b/app/stores/import.ts
@@ -1,0 +1,71 @@
+import type { AnkiImportPreview, AnkiImportStatus } from '~/types'
+
+export const useImportStore = defineStore('import', {
+  state: () => ({
+    importId: null as string | null,
+    preview: null as AnkiImportPreview | null,
+    status: null as AnkiImportStatus | null,
+    uploading: false,
+    loading: false,
+    deckConflicts: {} as Record<string, 'import' | 'skip'>,
+  }),
+
+  actions: {
+    async upload(file: File) {
+      this.uploading = true
+      try {
+        const { $api } = useNuxtApp()
+        const form = new FormData()
+        form.append('file', file)
+        const res = await $api<any>('/import/anki', { method: 'POST', body: form })
+        this.importId = res.data.id
+      } finally {
+        this.uploading = false
+      }
+    },
+
+    async fetchPreview() {
+      if (!this.importId) return
+      this.loading = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>(`/import/${this.importId}/preview`)
+        this.preview = res.data
+        // Pre-fill conflicts as 'import'
+        for (const deck of res.data.decks) {
+          if (deck.conflict) {
+            this.deckConflicts[deck.name] = 'import'
+          }
+        }
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async confirm() {
+      if (!this.importId) return
+      const { $api } = useNuxtApp()
+      await $api(`/import/${this.importId}/confirm`, {
+        method: 'POST',
+        body: { deck_conflicts: this.deckConflicts },
+      })
+      this.status = { status: 'processing', progress_percent: 0 }
+    },
+
+    async pollStatus() {
+      if (!this.importId) return
+      const { $api } = useNuxtApp()
+      const res = await $api<any>(`/import/${this.importId}/status`)
+      this.status = res.data
+    },
+
+    reset() {
+      this.importId = null
+      this.preview = null
+      this.status = null
+      this.uploading = false
+      this.loading = false
+      this.deckConflicts = {}
+    },
+  },
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -29,6 +29,7 @@ export interface Flashcard {
   source_note_id?: string | null
   tags: string[]
   type: string
+  cloze_index?: number | null
   front: string
   front_audio_url: string | null
   back: string
@@ -187,4 +188,30 @@ export interface NoteSnippet {
   title: string
   snippet: string
   topic_id: string
+}
+
+// Anki Import
+export interface AnkiImportDeckPreview {
+  name: string
+  cards_count: number
+  conflict: boolean
+}
+
+export interface AnkiImportPreview {
+  decks: AnkiImportDeckPreview[]
+  total_notes: number
+  total_cards: number
+  tags: string[]
+  media_count: number
+  note_types: { Basic: number; Cloze: number; Other: number }
+}
+
+export interface AnkiImportStatus {
+  status: 'pending' | 'previewing' | 'confirmed' | 'processing' | 'completed' | 'failed'
+  current_step?: string
+  total_cards?: number
+  imported_cards?: number
+  progress_percent?: number
+  stats?: { decks_created: number; cards_created: number; topics_created: number; media_extracted: number }
+  error?: string
 }

--- a/tests/composables/useCloze.test.ts
+++ b/tests/composables/useCloze.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { useCloze } from '~/composables/useCloze'
+
+describe('useCloze', () => {
+  const { renderQuestion, renderAnswer } = useCloze()
+
+  describe('renderQuestion', () => {
+    it('replaces cloze with blank', () => {
+      const result = renderQuestion('{{c1::Anatomy}} is the study of structures', 1)
+      expect(result).toContain('class="cloze-blank"')
+      expect(result).toContain('...')
+      expect(result).not.toContain('Anatomy')
+    })
+
+    it('shows hint when provided', () => {
+      const result = renderQuestion('Your {{c1::integumentary system::... system}} is your body', 1)
+      expect(result).toContain('... system')
+    })
+
+    it('only hides target cloze index', () => {
+      const result = renderQuestion('{{c1::Anatomy}} studies {{c2::structures}}', 1)
+      expect(result).toContain('cloze-blank')
+      expect(result).toContain('structures') // c2 shown as text
+    })
+
+    it('hides all clozes of same index', () => {
+      const result = renderQuestion('{{c1::A}} and {{c1::B}} are related', 1)
+      expect(result).not.toContain('>A<')
+      expect(result).not.toContain('>B<')
+    })
+
+    it('handles HTML inside cloze', () => {
+      const result = renderQuestion('{{c1::<b>Anatomy</b>::what}} is important', 1)
+      expect(result).toContain('cloze-blank')
+      expect(result).toContain('what')
+    })
+
+    it('handles empty cloze', () => {
+      const result = renderQuestion('Text {{c5::}} more text', 5)
+      expect(result).toContain('cloze-blank')
+    })
+  })
+
+  describe('renderAnswer', () => {
+    it('shows answer with highlight', () => {
+      const result = renderAnswer('{{c1::Anatomy}} is the study', 1)
+      expect(result).toContain('cloze-answer')
+      expect(result).toContain('Anatomy')
+    })
+
+    it('only highlights target cloze index', () => {
+      const result = renderAnswer('{{c1::Anatomy}} studies {{c2::structures}}', 1)
+      expect(result).toContain('cloze-answer')
+      expect(result).toContain('Anatomy')
+      expect(result).not.toContain('<strong class="cloze-answer">structures</strong>')
+    })
+
+    it('handles HTML inside cloze', () => {
+      const result = renderAnswer('{{c1::<b>Anatomy</b>}} is important', 1)
+      expect(result).toContain('cloze-answer')
+      expect(result).toContain('<b>Anatomy</b>')
+    })
+  })
+
+  describe('wrapper patterns', () => {
+    it('strips [[r::...]] wrappers', () => {
+      const result = renderQuestion('[[r::{{c1::Gross anatomy}} is visible]]', 1)
+      expect(result).toContain('cloze-blank')
+      expect(result).not.toContain('[[r')
+      expect(result).toContain('is visible')
+    })
+  })
+})


### PR DESCRIPTION
Closes #32

## Frontend da importação Anki + Cloze rendering

- Tela `/import` com 4 steps (upload, preview, progresso, concluído)
- Store import (upload, preview, confirm, pollStatus)
- Composable useCloze (lacuna, hint, multi-cloze, wrapper `[[r::]]`)
- Card.vue: suporte a Cloze + media (resolveMedia com URL backend)
- Sidebar + dashboard com links de importação
- UiSelect no dropdown de conflitos
- Linha "Resposta" separando frente/verso
- Botões sticky no bottom pra cards grandes
- Links desabilitados e imagens responsivas nos cards
- 10 testes (useCloze)
- 30 testes frontend total