### PR TITLE
feat(flashcard): imagens e lacunas no editor

### DIFF
--- a/app/components/flashcard/CardFormModal.vue
+++ b/app/components/flashcard/CardFormModal.vue
@@ -33,11 +33,12 @@
               placeholder="Digite a pergunta..."
               :min-height="80"
               :max-height="160"
+              enable-cloze
               @focus="previewSide = 'front'"
             />
           </div>
 
-          <div class="flex-1 flex flex-col">
+          <div v-if="!hasCloze" class="flex-1 flex flex-col">
             <label class="text-label mb-1 block">Verso</label>
             <UiRichInput
               v-model="form.back"
@@ -48,6 +49,9 @@
               :max-height="160"
               @focus="previewSide = 'back'"
             />
+          </div>
+          <div v-else class="flex-1 flex items-center justify-center rounded-lg border border-dashed border-base bg-surface-tertiary/50 px-4 py-6">
+            <p class="text-small text-base-muted text-center">O verso é gerado automaticamente pelas lacunas.</p>
           </div>
 
           <div>
@@ -61,12 +65,12 @@
               v-if="!isEdit"
               type="button"
               class="btn-secondary !py-1.5 !px-3 !min-h-0 !text-small"
-              :disabled="!form.front || !form.back || !form.deck_id || saving"
+              :disabled="!canSubmit"
               @click="submitAndContinue"
             >
               {{ saving ? 'Salvando...' : 'Salvar e criar outro' }}
             </button>
-            <button type="submit" class="btn-primary !py-1.5 !px-3 !min-h-0 !text-small" :disabled="!form.front || !form.back || !form.deck_id || saving">
+            <button type="submit" class="btn-primary !py-1.5 !px-3 !min-h-0 !text-small" :disabled="!canSubmit">
               {{ saving ? 'Salvando...' : 'Salvar' }}
             </button>
           </div>
@@ -76,6 +80,19 @@
       <!-- Preview -->
       <div class="hidden md:flex flex-col items-center w-72 shrink-0 pt-10">
         <p class="text-label mb-3">Preview</p>
+        <!-- Cloze index selector -->
+        <div v-if="hasCloze && clozeIndices.length > 1" class="flex gap-1 mb-3">
+          <button
+            v-for="idx in clozeIndices"
+            :key="idx"
+            type="button"
+            class="px-2 py-0.5 rounded text-micro font-medium transition-colors"
+            :class="previewClozeIndex === idx ? 'bg-accent-primary text-white' : 'bg-surface-tertiary text-base-muted hover:text-base-primary'"
+            @click="previewClozeIndex = idx"
+          >
+            c{{ idx }}
+          </button>
+        </div>
         <div class="w-full card-scene">
           <div class="card-inner" :class="previewSide === 'back' && 'flipped'">
             <div class="card-face card-front" @click="flipPreview">
@@ -186,13 +203,38 @@ const selectedDeckName = computed(() =>
 
 const isEmpty = (html: string) => !html || html === '<p></p>'
 
-const frontPreview = computed(() =>
-  isEmpty(form.front) ? '<span style="opacity:0.4">Sua pergunta aqui...</span>' : form.front,
-)
+const hasCloze = computed(() => /\{\{c\d+::/.test(form.front))
 
-const backPreview = computed(() =>
-  isEmpty(form.back) ? '<span style="opacity:0.4">Sua resposta aqui...</span>' : form.back,
-)
+const clozeIndices = computed(() => {
+  const matches = form.front.matchAll(/\{\{c(\d+)::/g)
+  const indices = [...new Set([...matches].map(m => parseInt(m[1])))]
+  return indices.sort((a, b) => a - b)
+})
+
+const previewClozeIndex = ref(1)
+
+watch(clozeIndices, (indices) => {
+  if (indices.length && !indices.includes(previewClozeIndex.value)) {
+    previewClozeIndex.value = indices[0]
+  }
+})
+
+const canSubmit = computed(() => {
+  if (!form.front || !form.deck_id || saving.value) return false
+  return hasCloze.value || !!form.back
+})
+
+const { renderQuestion, renderAnswer } = useCloze()
+
+const frontPreview = computed(() => {
+  if (isEmpty(form.front)) return '<span style="opacity:0.4">Sua pergunta aqui...</span>'
+  return hasCloze.value ? renderQuestion(form.front, previewClozeIndex.value) : form.front
+})
+
+const backPreview = computed(() => {
+  if (hasCloze.value) return renderAnswer(form.front, previewClozeIndex.value)
+  return isEmpty(form.back) ? '<span style="opacity:0.4">Sua resposta aqui...</span>' : form.back
+})
 
 async function loadTopics() {
   try {

--- a/app/components/topic/NoteEditor.vue
+++ b/app/components/topic/NoteEditor.vue
@@ -17,8 +17,9 @@ import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Placeholder from '@tiptap/extension-placeholder'
+import Image from '@tiptap/extension-image'
 import { Callout } from '~/extensions/callout'
-import { Bold, Italic, Underline as UnderlineIcon, Heading1, Heading2, Heading3, List, ListOrdered, Quote, AlertTriangle, Lightbulb, ShieldAlert } from 'lucide-vue-next'
+import { Bold, Italic, Underline as UnderlineIcon, Heading1, Heading2, Heading3, List, ListOrdered, Quote, AlertTriangle, Lightbulb, ShieldAlert, ImagePlus } from 'lucide-vue-next'
 
 const props = defineProps<{
   modelValue?: Record<string, any> | null
@@ -34,6 +35,7 @@ const editor = useEditor({
     StarterKit,
     Underline,
     Callout,
+    Image.configure({ inline: false, allowBase64: false }),
     Placeholder.configure({ placeholder: 'Comece a escrever...' }),
   ],
   onUpdate: ({ editor }) => {
@@ -63,13 +65,43 @@ const toolbar = computed(() => {
     { label: 'Lista', icon: List, active: () => e.isActive('bulletList'), action: () => e.chain().focus().toggleBulletList().run() },
     { label: 'Lista numerada', icon: ListOrdered, active: () => e.isActive('orderedList'), action: () => e.chain().focus().toggleOrderedList().run() },
     { label: 'Citação', icon: Quote, active: () => e.isActive('blockquote'), action: () => e.chain().focus().toggleBlockquote().run() },
+    { label: 'Imagem', icon: ImagePlus, active: () => false, action: () => triggerImageUpload() },
     { label: '❌ Erro', icon: AlertTriangle, active: () => e.isActive('callout', { type: 'error' }), action: () => e.isActive('callout') ? e.chain().focus().unsetCallout().run() : e.chain().focus().setCallout('error').run() },
     { label: '💡 Insight', icon: Lightbulb, active: () => e.isActive('callout', { type: 'insight' }), action: () => e.isActive('callout') ? e.chain().focus().unsetCallout().run() : e.chain().focus().setCallout('insight').run() },
     { label: '⚠ Pegadinha', icon: ShieldAlert, active: () => e.isActive('callout', { type: 'gotcha' }), action: () => e.isActive('callout') ? e.chain().focus().unsetCallout().run() : e.chain().focus().setCallout('gotcha').run() },
   ]
 })
 
+// Image upload
+const imageInput = ref<HTMLInputElement | null>(null)
+const { uploadImage } = useImageUpload()
+
+function triggerImageUpload() {
+  if (!imageInput.value) {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/jpeg,image/png,image/webp,image/gif'
+    input.style.display = 'none'
+    input.addEventListener('change', handleImageSelect)
+    document.body.appendChild(input)
+    imageInput.value = input
+  }
+  imageInput.value.value = ''
+  imageInput.value.click()
+}
+
+async function handleImageSelect(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file || !editor.value) return
+
+  const url = await uploadImage(file)
+  if (url) {
+    editor.value.chain().focus().setImage({ src: url }).run()
+  }
+}
+
 onBeforeUnmount(() => {
+  if (imageInput.value) imageInput.value.remove()
   editor.value?.destroy()
 })
 </script>
@@ -95,5 +127,10 @@ onBeforeUnmount(() => {
   pointer-events: none;
   height: 0;
   opacity: 0.4;
+}
+.prose-editor .tiptap img {
+  max-width: 100%;
+  border-radius: 0.5rem;
+  margin: 0.5em 0;
 }
 </style>

--- a/app/components/ui/RichInput.vue
+++ b/app/components/ui/RichInput.vue
@@ -46,7 +46,9 @@ import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Placeholder from '@tiptap/extension-placeholder'
-import { Bold, Italic, Underline as UnderlineIcon, List, ListOrdered, Mic } from 'lucide-vue-next'
+import Image from '@tiptap/extension-image'
+import { ClozeMarker, markToCloze, clozeToMark, getNextClozeIndex } from '~/extensions/cloze-marker'
+import { Bold, Italic, Underline as UnderlineIcon, List, ListOrdered, Mic, ImagePlus, Brackets } from 'lucide-vue-next'
 
 const props = withDefaults(defineProps<{
   modelValue?: string
@@ -55,6 +57,8 @@ const props = withDefaults(defineProps<{
   placeholder?: string
   minHeight?: number
   maxHeight?: number
+  enableImage?: boolean
+  enableCloze?: boolean
 }>(), {
   modelValue: '',
   audioBlob: null,
@@ -62,6 +66,8 @@ const props = withDefaults(defineProps<{
   placeholder: '',
   minHeight: 80,
   maxHeight: 200,
+  enableImage: true,
+  enableCloze: false,
 })
 
 const emit = defineEmits<{
@@ -70,8 +76,18 @@ const emit = defineEmits<{
   (e: 'focus'): void
 }>()
 
+// Convert cloze syntax to marks for editor display
+function toEditorContent(val: string): string {
+  return props.enableCloze ? clozeToMark(val) : val
+}
+
+// Convert marks back to cloze syntax for storage
+function toStorageContent(html: string): string {
+  return props.enableCloze ? markToCloze(html) : html
+}
+
 const editor = useEditor({
-  content: props.modelValue,
+  content: toEditorContent(props.modelValue),
   extensions: [
     StarterKit.configure({
       heading: false,
@@ -81,9 +97,11 @@ const editor = useEditor({
     }),
     Underline.configure({}),
     Placeholder.configure({ placeholder: props.placeholder }),
+    ...(props.enableImage ? [Image.configure({ inline: false, allowBase64: false })] : []),
+    ...(props.enableCloze ? [ClozeMarker] : []),
   ],
   onUpdate: ({ editor }) => {
-    emit('update:modelValue', editor.getHTML())
+    emit('update:modelValue', toStorageContent(editor.getHTML()))
   },
   onFocus: () => {
     emit('focus')
@@ -92,22 +110,87 @@ const editor = useEditor({
 
 watch(() => props.modelValue, (val) => {
   if (!editor.value) return
-  if (editor.value.getHTML() !== val) {
-    editor.value.commands.setContent(val || '')
+  const editorContent = toStorageContent(editor.value.getHTML())
+  if (editorContent !== val) {
+    editor.value.commands.setContent(toEditorContent(val || ''))
   }
 })
+
+function insertCloze(event?: MouseEvent) {
+  if (!editor.value) return
+  const { from, to } = editor.value.state.selection
+  if (from === to) return // No selection
+
+  const html = editor.value.getHTML()
+  const useLastIndex = event?.shiftKey
+  const nextIndex = useLastIndex
+    ? Math.max(1, getNextClozeIndex(html) - 1)
+    : getNextClozeIndex(html)
+
+  editor.value.chain().focus().setCloze(nextIndex).run()
+}
 
 const toolbar = computed(() => {
   if (!editor.value) return []
   const e = editor.value
-  return [
+  const items = [
     { label: 'Negrito', icon: Bold, active: () => e.isActive('bold'), action: () => e.chain().focus().toggleBold().run() },
     { label: 'Itálico', icon: Italic, active: () => e.isActive('italic'), action: () => e.chain().focus().toggleItalic().run() },
     { label: 'Sublinhado', icon: UnderlineIcon, active: () => e.isActive('underline'), action: () => e.chain().focus().toggleUnderline().run() },
     { label: 'Lista', icon: List, active: () => e.isActive('bulletList'), action: () => e.chain().focus().toggleBulletList().run() },
     { label: 'Lista numerada', icon: ListOrdered, active: () => e.isActive('orderedList'), action: () => e.chain().focus().toggleOrderedList().run() },
   ]
+  if (props.enableImage) {
+    items.push({ label: 'Imagem', icon: ImagePlus, active: () => false, action: () => triggerImageUpload() })
+  }
+  if (props.enableCloze) {
+    items.push({ label: 'Lacuna (Ctrl+Shift+C)', icon: Brackets, active: () => e.isActive('clozeMarker'), action: (event: MouseEvent) => insertCloze(event) })
+  }
+  return items
 })
+
+// Image upload
+const imageInput = ref<HTMLInputElement | null>(null)
+const { uploadImage } = useImageUpload()
+
+function triggerImageUpload() {
+  if (!imageInput.value) {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/jpeg,image/png,image/webp,image/gif'
+    input.style.display = 'none'
+    input.addEventListener('change', handleImageSelect)
+    document.body.appendChild(input)
+    imageInput.value = input
+  }
+  imageInput.value.value = ''
+  imageInput.value.click()
+}
+
+async function handleImageSelect(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file || !editor.value) return
+
+  const url = await uploadImage(file)
+  if (url) {
+    editor.value.chain().focus().setImage({ src: url }).run()
+  }
+}
+
+// Keyboard shortcut for cloze
+onMounted(() => {
+  if (props.enableCloze) {
+    document.addEventListener('keydown', handleClozeShortcut)
+  }
+})
+
+function handleClozeShortcut(e: KeyboardEvent) {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'c') {
+    if (!editor.value?.isFocused) return
+    e.preventDefault()
+    insertCloze()
+  }
+}
 
 // Audio recording — stores blob locally, upload happens on card save
 const recording = ref(false)
@@ -176,6 +259,8 @@ onBeforeUnmount(() => {
   mediaRecorder?.stop()
   if (timerInterval) clearInterval(timerInterval)
   if (localAudioUrl.value) URL.revokeObjectURL(localAudioUrl.value)
+  if (imageInput.value) imageInput.value.remove()
+  if (props.enableCloze) document.removeEventListener('keydown', handleClozeShortcut)
   editor.value?.destroy()
 })
 </script>
@@ -195,5 +280,25 @@ onBeforeUnmount(() => {
   pointer-events: none;
   height: 0;
   color: var(--text-muted);
+}
+.rich-input .tiptap img {
+  max-width: 100%;
+  border-radius: 0.5rem;
+  margin: 0.5em 0;
+}
+.rich-input .tiptap .cloze-chip {
+  background: var(--color-primary-100, rgba(59, 130, 246, 0.15));
+  border-radius: 4px;
+  padding: 1px 4px;
+  border: 1px solid var(--color-primary-300, rgba(59, 130, 246, 0.3));
+  position: relative;
+}
+.rich-input .tiptap .cloze-chip::after {
+  content: attr(data-cloze-index);
+  font-size: 0.6em;
+  font-weight: 700;
+  color: var(--color-primary-600, #2563eb);
+  vertical-align: super;
+  margin-left: 2px;
 }
 </style>

--- a/app/composables/useImageUpload.ts
+++ b/app/composables/useImageUpload.ts
@@ -1,0 +1,59 @@
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+const MAX_DIMENSION = 1920
+const QUALITY = 0.8
+
+function compressImage(file: File): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => {
+      let { width, height } = img
+      if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+        const ratio = Math.min(MAX_DIMENSION / width, MAX_DIMENSION / height)
+        width = Math.round(width * ratio)
+        height = Math.round(height * ratio)
+      }
+
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')!
+      ctx.drawImage(img, 0, 0, width, height)
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) resolve(blob)
+          else reject(new Error('Falha na compressão'))
+        },
+        'image/webp',
+        QUALITY,
+      )
+    }
+    img.onerror = () => reject(new Error('Falha ao carregar imagem'))
+    img.src = URL.createObjectURL(file)
+  })
+}
+
+export function useImageUpload() {
+  const { $api } = useNuxtApp()
+  const toast = useToast()
+
+  async function uploadImage(file: File): Promise<string | null> {
+    if (file.size > MAX_SIZE) {
+      toast.show('Imagem muito grande (máx. 5MB).', 'error')
+      return null
+    }
+
+    try {
+      const compressed = await compressImage(file)
+      const formData = new FormData()
+      formData.append('image', compressed, 'image.webp')
+      const res = await $api<any>('/images/upload', { method: 'POST', body: formData })
+      return res.data.url
+    } catch {
+      toast.show('Erro ao enviar imagem.', 'error')
+      return null
+    }
+  }
+
+  return { uploadImage }
+}

--- a/app/extensions/cloze-marker.ts
+++ b/app/extensions/cloze-marker.ts
@@ -1,0 +1,113 @@
+import { Mark, mergeAttributes } from '@tiptap/core'
+
+export interface ClozeMarkerOptions {
+  HTMLAttributes: Record<string, any>
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    clozeMarker: {
+      setCloze: (index: number) => ReturnType
+      unsetCloze: () => ReturnType
+    }
+  }
+}
+
+export const ClozeMarker = Mark.create<ClozeMarkerOptions>({
+  name: 'clozeMarker',
+
+  addOptions() {
+    return { HTMLAttributes: {} }
+  },
+
+  addAttributes() {
+    return {
+      index: {
+        default: 1,
+        parseHTML: (el) => parseInt(el.getAttribute('data-cloze-index') || '1'),
+        renderHTML: (attrs) => ({ 'data-cloze-index': attrs.index }),
+      },
+      hint: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-cloze-hint'),
+        renderHTML: (attrs) => attrs.hint ? { 'data-cloze-hint': attrs.hint } : {},
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-cloze-index]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { class: 'cloze-chip' }), 0]
+  },
+
+  addCommands() {
+    return {
+      setCloze: (index: number) => ({ chain, state }) => {
+        const { to } = state.selection
+        return chain()
+          .setMark(this.name, { index })
+          .setTextSelection(to)
+          .unsetMark(this.name)
+          .run()
+      },
+      unsetCloze: () => ({ commands }) => {
+        return commands.unsetMark(this.name)
+      },
+    }
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-c': () => {
+        // Will be handled by the component that knows the next index
+        return false
+      },
+    }
+  },
+})
+
+/**
+ * Convert cloze mark HTML to {{c1::text}} syntax for backend storage.
+ */
+export function markToCloze(html: string): string {
+  const div = document.createElement('div')
+  div.innerHTML = html
+  div.querySelectorAll('span[data-cloze-index]').forEach((el) => {
+    const index = el.getAttribute('data-cloze-index') || '1'
+    const hint = el.getAttribute('data-cloze-hint')
+    const text = el.textContent || ''
+    const cloze = hint ? `{{c${index}::${text}::${hint}}}` : `{{c${index}::${text}}}`
+    el.replaceWith(cloze)
+  })
+  return div.innerHTML
+}
+
+/**
+ * Convert {{c1::text}} syntax to cloze mark HTML for editor display.
+ */
+export function clozeToMark(text: string): string {
+  return text.replace(
+    /\{\{c(\d+)::([\s\S]*?)(?:::([\s\S]+?))?\}\}/g,
+    (_match, index, answer, hint) => {
+      const attrs = hint
+        ? `data-cloze-index="${index}" data-cloze-hint="${hint}"`
+        : `data-cloze-index="${index}"`
+      return `<span class="cloze-chip" ${attrs}>${answer}</span>`
+    },
+  )
+}
+
+/**
+ * Get the next cloze index from editor HTML content.
+ */
+export function getNextClozeIndex(html: string): number {
+  const matches = html.matchAll(/data-cloze-index="(\d+)"/g)
+  let max = 0
+  for (const m of matches) {
+    max = Math.max(max, parseInt(m[1]))
+  }
+  return max + 1
+}

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -80,20 +80,40 @@
       </div>
 
       <div v-else-if="flashcardStore.flashcards.length" class="space-y-2">
-        <div v-for="card in flashcardStore.flashcards" :key="card.id" class="card group">
+        <div v-for="item in groupedCards" :key="item.id" class="card group">
           <div class="flex items-center justify-between gap-4">
-            <div class="text-base-primary text-small truncate flex-1">{{ stripHtml(card.front) }}</div>
+            <div class="flex items-center gap-2 text-base-primary text-small truncate flex-1">
+              <span class="truncate">{{ stripHtml(item.front) }}</span>
+              <span v-if="item.clozeCount > 1" class="shrink-0 text-micro bg-accent-primary-subtle text-accent-primary px-1.5 py-0.5 rounded-full font-medium">
+                {{ item.clozeCount }} lacunas
+              </span>
+              <span v-else-if="item.type === 'cloze'" class="shrink-0 text-micro bg-accent-primary-subtle text-accent-primary px-1.5 py-0.5 rounded-full font-medium">
+                lacuna
+              </span>
+            </div>
             <div class="flex items-center gap-3 shrink-0">
-              <button class="text-micro text-accent-primary hover:underline" @click="toggleCard(card.id)">
-                {{ expandedCards.has(card.id) ? 'Ocultar' : 'Ver verso' }}
+              <button v-if="item.type !== 'cloze'" class="text-micro text-accent-primary hover:underline" @click="toggleCard(item.id)">
+                {{ expandedCards.has(item.id) ? 'Ocultar' : 'Ver verso' }}
               </button>
-              <button class="text-micro text-accent-primary hover:underline" @click="openEditCard(card)">Editar</button>
-              <button class="text-micro text-danger" @click="confirmDeleteCard(card.id)">Remover</button>
+              <button v-else class="text-micro text-accent-primary hover:underline" @click="toggleCard(item.id)">
+                {{ expandedCards.has(item.id) ? 'Ocultar' : 'Ver lacunas' }}
+              </button>
+              <button class="text-micro text-accent-primary hover:underline" @click="openEditCard(item.card)">Editar</button>
+              <button class="text-micro text-danger" @click="confirmDeleteCard(item.card.id)">Remover</button>
             </div>
           </div>
           <Transition name="expand">
-            <div v-if="expandedCards.has(card.id)" class="bg-surface-tertiary rounded-lg p-3 mt-2">
-              <div class="text-base-secondary text-small card-content" v-html="card.back" />
+            <div v-if="expandedCards.has(item.id)" class="bg-surface-tertiary rounded-lg p-3 mt-2">
+              <!-- Basic card: show back -->
+              <div v-if="item.type !== 'cloze'" class="text-base-secondary text-small card-content" v-html="item.card.back" />
+              <!-- Cloze group: show individual cards -->
+              <div v-else class="space-y-2">
+                <div v-for="sibling in item.siblings" :key="sibling.id" class="flex items-center gap-3 text-small">
+                  <span class="shrink-0 text-micro font-bold text-accent-primary">c{{ sibling.cloze_index }}</span>
+                  <span class="text-base-secondary">{{ clozePreview(sibling) }}</span>
+                  <span class="ml-auto text-micro text-base-muted">{{ sibling.state }}</span>
+                </div>
+              </div>
             </div>
           </Transition>
         </div>
@@ -119,7 +139,57 @@ const toast = useToast()
 const deckId = route.params.id as string
 
 function stripHtml(html: string): string {
-  return html?.replace(/<[^>]*>/g, '') ?? ''
+  return html?.replace(/<[^>]*>/g, '').replace(/\{\{c\d+::.*?(?:::.*?)?\}\}/g, '___') ?? ''
+}
+
+interface GroupedCard {
+  id: string
+  front: string
+  type: string
+  card: import('~/types').Flashcard
+  clozeCount: number
+  siblings: import('~/types').Flashcard[]
+}
+
+const groupedCards = computed<GroupedCard[]>(() => {
+  const cards = flashcardStore.flashcards
+  const seen = new Set<string>()
+  const result: GroupedCard[] = []
+
+  for (const card of cards) {
+    if (card.cloze_group_id) {
+      if (seen.has(card.cloze_group_id)) continue
+      seen.add(card.cloze_group_id)
+      const siblings = cards
+        .filter(c => c.cloze_group_id === card.cloze_group_id)
+        .sort((a, b) => (a.cloze_index ?? 0) - (b.cloze_index ?? 0))
+      result.push({
+        id: card.cloze_group_id,
+        front: card.front,
+        type: 'cloze',
+        card: siblings[0],
+        clozeCount: siblings.length,
+        siblings,
+      })
+    } else {
+      result.push({
+        id: card.id,
+        front: card.front,
+        type: card.type,
+        card,
+        clozeCount: card.type === 'cloze' ? 1 : 0,
+        siblings: [],
+      })
+    }
+  }
+  return result
+})
+
+function clozePreview(card: import('~/types').Flashcard): string {
+  const text = stripHtml(card.front)
+  // Show which word this cloze tests
+  const match = card.front.match(new RegExp(`\\{\\{c${card.cloze_index}::(.*?)(?:::.*?)?\\}\\}`))
+  return match ? match[1] : text
 }
 
 const showAdd = ref(false)

--- a/app/stores/flashcard.ts
+++ b/app/stores/flashcard.ts
@@ -19,25 +19,39 @@ export const useFlashcardStore = defineStore('flashcard', {
       }
     },
 
-    async create(deckId: string, data: { front: string; back: string; topic_id?: string; tags?: string[]; front_audio_url?: string; back_audio_url?: string }) {
+    async create(deckId: string, data: { front: string; back?: string; topic_id?: string; tags?: string[]; front_audio_url?: string; back_audio_url?: string }) {
       const { $api } = useNuxtApp()
       const res = await $api<any>(`/decks/${deckId}/flashcards`, { method: 'POST', body: data })
-      this.flashcards.unshift(res.data)
+      const cards = Array.isArray(res.data) ? res.data : [res.data]
+      this.flashcards.unshift(...cards)
       return res.data
     },
 
     async update(id: string, data: { front?: string; back?: string; topic_id?: string; tags?: string[]; front_audio_url?: string | null; back_audio_url?: string | null }) {
       const { $api } = useNuxtApp()
       const res = await $api<any>(`/flashcards/${id}`, { method: 'PUT', body: data })
-      const idx = this.flashcards.findIndex(f => f.id === id)
-      if (idx !== -1) this.flashcards[idx] = res.data
+      const cards = Array.isArray(res.data) ? res.data as Flashcard[] : [res.data as Flashcard]
+      // Remove old cards from the same cloze group or the single card
+      const groupId = cards[0]?.cloze_group_id
+      if (groupId) {
+        this.flashcards = this.flashcards.filter(f => f.cloze_group_id !== groupId && f.id !== id)
+      } else {
+        this.flashcards = this.flashcards.filter(f => f.id !== id)
+      }
+      this.flashcards.unshift(...cards)
       return res.data
     },
 
     async remove(id: string) {
       const { $api } = useNuxtApp()
+      const card = this.flashcards.find(f => f.id === id)
       await $api(`/flashcards/${id}`, { method: 'DELETE' })
-      this.flashcards = this.flashcards.filter(f => f.id !== id)
+      // Remove all siblings if cloze group
+      if (card?.cloze_group_id) {
+        this.flashcards = this.flashcards.filter(f => f.cloze_group_id !== card.cloze_group_id)
+      } else {
+        this.flashcards = this.flashcards.filter(f => f.id !== id)
+      }
     },
   },
 })

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -30,6 +30,7 @@ export interface Flashcard {
   tags: string[]
   type: string
   cloze_index?: number | null
+  cloze_group_id?: string | null
   front: string
   front_audio_url: string | null
   back: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@pinia/nuxt": "^0.11.3",
         "@tailwindcss/vite": "^4.2.2",
+        "@tiptap/extension-image": "^3.22.4",
         "@tiptap/extension-placeholder": "^3.22.3",
         "@tiptap/extension-underline": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
@@ -4279,12 +4280,6 @@
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "license": "MIT"
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.13",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
@@ -5123,16 +5118,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
-      "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.4.tgz",
+      "integrity": "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.22.3"
+        "@tiptap/pm": "3.22.4"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -5314,6 +5309,19 @@
         "@tiptap/pm": "^3.22.3"
       }
     },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.4.tgz",
+      "integrity": "sha512-ZDc+fLaratTQ4IgnKcJJwfUgUgpcHjbZSBi6UQAILJwkflMy1Zxj8mpbma5P934nLSI+uDnR5ret6ZZLNITKhA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4"
+      }
+    },
     "node_modules/@tiptap/extension-italic": {
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.3.tgz",
@@ -5477,27 +5485,21 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
-      "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.4.tgz",
+      "integrity": "sha512-hj8Qka6WcHRllHUdeSjDnq2XaisUo4KsoGJc1WcFpoa1Yd+OeD861zUMnV7DFVGdZRy45Obht0CUYJpXQ4yA4w==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
         "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
         "prosemirror-schema-list": "^1.5.0",
         "prosemirror-state": "^1.4.3",
         "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
         "prosemirror-transform": "^1.10.2",
         "prosemirror-view": "^1.38.1"
       },
@@ -5853,28 +5855,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -6678,12 +6658,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -7537,12 +7511,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "license": "MIT"
     },
     "node_modules/croner": {
       "version": "10.0.1",
@@ -11070,15 +11038,6 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkifyjs": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
@@ -11268,35 +11227,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11312,12 +11242,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -12817,15 +12741,6 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-commands": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -12872,16 +12787,6 @@
         "rope-sequence": "^1.3.0"
       }
     },
-    "node_modules/prosemirror-inputrules": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
-      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-keymap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
@@ -12892,29 +12797,6 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-      "license": "MIT",
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
@@ -12922,15 +12804,6 @@
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -12968,33 +12841,6 @@
         "prosemirror-view": "^1.41.4"
       }
     },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
-      }
-    },
-    "node_modules/prosemirror-trailing-node/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prosemirror-transform": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
@@ -13027,15 +12873,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14768,12 +14605,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@pinia/nuxt": "^0.11.3",
     "@tailwindcss/vite": "^4.2.2",
+    "@tiptap/extension-image": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.3",
     "@tiptap/extension-underline": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",

--- a/tests/composables/clozeMarker.test.ts
+++ b/tests/composables/clozeMarker.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { markToCloze, clozeToMark, getNextClozeIndex } from '~/extensions/cloze-marker'
+
+describe('cloze-marker helpers', () => {
+  describe('clozeToMark', () => {
+    it('converts cloze syntax to mark HTML', () => {
+      const result = clozeToMark('{{c1::Brasília}} é a capital')
+      expect(result).toContain('data-cloze-index="1"')
+      expect(result).toContain('class="cloze-chip"')
+      expect(result).toContain('Brasília')
+    })
+
+    it('converts multiple clozes', () => {
+      const result = clozeToMark('{{c1::A}} e {{c2::B}}')
+      expect(result).toContain('data-cloze-index="1"')
+      expect(result).toContain('data-cloze-index="2"')
+    })
+
+    it('handles hint', () => {
+      const result = clozeToMark('{{c1::Brasília::capital do...}}')
+      expect(result).toContain('data-cloze-hint="capital do..."')
+    })
+
+    it('returns text unchanged when no cloze', () => {
+      expect(clozeToMark('texto normal')).toBe('texto normal')
+    })
+  })
+
+  describe('markToCloze', () => {
+    it('converts mark HTML back to cloze syntax', () => {
+      const html = '<span class="cloze-chip" data-cloze-index="1">Brasília</span> é a capital'
+      const result = markToCloze(html)
+      expect(result).toBe('{{c1::Brasília}} é a capital')
+    })
+
+    it('converts with hint', () => {
+      const html = '<span class="cloze-chip" data-cloze-index="1" data-cloze-hint="dica">Brasília</span>'
+      const result = markToCloze(html)
+      expect(result).toBe('{{c1::Brasília::dica}}')
+    })
+
+    it('handles multiple marks', () => {
+      const html = '<span class="cloze-chip" data-cloze-index="1">A</span> e <span class="cloze-chip" data-cloze-index="2">B</span>'
+      const result = markToCloze(html)
+      expect(result).toContain('{{c1::A}}')
+      expect(result).toContain('{{c2::B}}')
+    })
+  })
+
+  describe('getNextClozeIndex', () => {
+    it('returns 1 for empty content', () => {
+      expect(getNextClozeIndex('')).toBe(1)
+    })
+
+    it('returns next index after existing', () => {
+      const html = '<span data-cloze-index="2">B</span>'
+      expect(getNextClozeIndex(html)).toBe(3)
+    })
+
+    it('returns max + 1 with multiple indices', () => {
+      const html = '<span data-cloze-index="1">A</span><span data-cloze-index="3">C</span>'
+      expect(getNextClozeIndex(html)).toBe(4)
+    })
+  })
+})


### PR DESCRIPTION
## Fase 3.1.1 — Editor: Imagens + Cloze (Frontend)

### Imagens
- Extensão `@tiptap/extension-image` nos dois editores (RichInput + NoteEditor)
- Composable `useImageUpload` com compressão client-side (WebP, 1920px, 80%)
- Botão na toolbar dos dois editores

### Cloze (Lacunas)
- Extensão Tiptap `ClozeMarker` com chip visual
- Botão + atalho `Ctrl+Shift+C`, Shift pra agrupar índice
- Campo verso oculto quando tem lacuna
- Preview com seletor de lacuna (c1, c2, c3...)
- Listagem agrupada no deck com badge "N lacunas"
- Store atualizado pra tratar arrays (cloze)

### Testes
- 40 testes frontend (10 novos: clozeMarker helpers)

Closes #34