### PR TITLE
feat(credit): badges de uso e modal de upgrade

### DIFF
--- a/app/components/ui/UpgradeModal.vue
+++ b/app/components/ui/UpgradeModal.vue
@@ -1,0 +1,49 @@
+<template>
+  <UiModal v-model="open" size="sm" aria-label="Upgrade de plano">
+    <div class="text-center py-4">
+      <div class="w-12 h-12 rounded-full bg-accent-primary-subtle flex items-center justify-center mx-auto mb-4">
+        <Zap :size="24" class="text-accent-primary" />
+      </div>
+      <h2 class="text-headline mb-2">Limite atingido</h2>
+      <p class="text-base-secondary text-small mb-6">{{ message }}</p>
+      <div class="flex gap-3 justify-center">
+        <button class="btn-secondary" @click="open = false">Depois</button>
+        <button class="btn-primary" @click="open = false">
+          Em breve
+        </button>
+      </div>
+    </div>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import { Zap } from 'lucide-vue-next'
+
+const props = withDefaults(defineProps<{
+  feature?: string
+  planRequired?: string
+}>(), {
+  feature: '',
+  planRequired: 'pro',
+})
+
+const open = defineModel<boolean>({ required: true })
+
+const featureLabels: Record<string, string> = {
+  cards_ai: 'cards IA',
+  pdf_upload: 'uploads de PDF',
+  agent_chat: 'dúvidas',
+  podcast: 'podcasts',
+}
+
+const planLabels: Record<string, string> = {
+  pro: 'Pro',
+  premium: 'Premium',
+}
+
+const message = computed(() => {
+  const label = featureLabels[props.feature] || 'esta feature'
+  const plan = planLabels[props.planRequired] || 'Pro'
+  return `Seus ${label} do mês acabaram. Faça upgrade pro plano ${plan} pra continuar.`
+})
+</script>

--- a/app/composables/useFeatureUsage.ts
+++ b/app/composables/useFeatureUsage.ts
@@ -1,0 +1,50 @@
+interface FeatureData {
+  used: number
+  limit: number | null
+  remaining: number | null
+}
+
+interface UsageData {
+  plan: string
+  period_start: string
+  period_end: string
+  features: Record<string, FeatureData>
+}
+
+export function useFeatureUsage() {
+  const { $api } = useNuxtApp()
+  const usage = ref<UsageData | null>(null)
+  const loading = ref(false)
+
+  async function fetchUsage() {
+    loading.value = true
+    try {
+      const res = await $api<any>('/usage')
+      usage.value = res.data
+    } catch {
+      // Silently fail — usage is non-critical
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function canUse(feature: string): boolean {
+    if (!usage.value) return true
+    const f = usage.value.features[feature]
+    if (!f || f.limit === null) return true
+    return f.remaining !== null && f.remaining > 0
+  }
+
+  function remaining(feature: string): number | null {
+    if (!usage.value) return null
+    return usage.value.features[feature]?.remaining ?? null
+  }
+
+  function isLimited(feature: string): boolean {
+    if (!usage.value) return false
+    const f = usage.value.features[feature]
+    return f?.limit !== null && f?.limit !== undefined
+  }
+
+  return { usage, loading, fetchUsage, canUse, remaining, isLimited }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -23,6 +23,12 @@
       :type="toast.state.type"
       :visible="toast.state.visible"
     />
+
+    <UiUpgradeModal
+      v-model="showUpgrade"
+      :feature="upgradeFeature"
+      :plan-required="upgradePlan"
+    />
   </div>
 </template>
 
@@ -31,4 +37,16 @@ import { Sun, Moon } from 'lucide-vue-next'
 
 const toast = useToast()
 const { colorMode, toggle } = useColorMode()
+
+const showUpgrade = ref(false)
+const upgradeFeature = ref('')
+const upgradePlan = ref('pro')
+
+onMounted(() => {
+  window.addEventListener('feature-limit-reached', ((e: CustomEvent) => {
+    upgradeFeature.value = e.detail?.feature || ''
+    upgradePlan.value = e.detail?.planRequired || 'pro'
+    showUpgrade.value = true
+  }) as EventListener)
+})
 </script>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -91,6 +91,24 @@
       </div>
     </div>
 
+    <!-- AI Usage -->
+    <div v-if="featureUsage.usage.value && hasLimitedFeatures" class="mt-8">
+      <p class="text-label mb-3">Uso de IA este mês</p>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div v-for="(data, key) in limitedFeatures" :key="key" class="card py-3 px-4">
+          <p class="text-micro text-base-muted mb-1">{{ featureLabels[key] }}</p>
+          <p class="text-title text-base-primary">{{ data.used }}/{{ data.limit }}</p>
+          <div class="h-1.5 rounded-full bg-surface-tertiary mt-2 overflow-hidden">
+            <div
+              class="h-1.5 rounded-full transition-all"
+              :class="data.remaining === 0 ? 'bg-danger' : data.used / data.limit > 0.8 ? 'bg-warning' : 'bg-accent-primary'"
+              :style="{ width: Math.min(100, (data.used / data.limit) * 100) + '%' }"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Quick actions -->
     <p class="text-label mt-12 mb-4">Ações rápidas</p>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
@@ -184,6 +202,27 @@ import type { Stats, TopicProgress, BacklogStats } from '~/types'
 
 const auth = useAuthStore()
 const deckStore = useDeckStore()
+const featureUsage = useFeatureUsage()
+
+const featureLabels: Record<string, string> = {
+  cards_ai: 'Cards IA',
+  pdf_upload: 'Uploads PDF',
+  agent_chat: 'Tirar dúvidas',
+  podcast: 'Podcasts',
+}
+
+const limitedFeatures = computed(() => {
+  if (!featureUsage.usage.value) return {}
+  const result: Record<string, any> = {}
+  for (const [key, data] of Object.entries(featureUsage.usage.value.features)) {
+    if (data.limit !== null && data.limit > 0) {
+      result[key] = data
+    }
+  }
+  return result
+})
+
+const hasLimitedFeatures = computed(() => Object.keys(limitedFeatures.value).length > 0)
 
 const stats = ref<Stats | null>(null)
 const topicProgress = ref<TopicProgress[]>([])
@@ -222,6 +261,7 @@ async function loadData() {
   backlog.value = backlogRes.data
   retentionSuggestion.value = retRes.data
   survivalActive.value = settingsRes.data.survival_mode ?? false
+  featureUsage.fetchUsage()
 }
 
 async function toggleSurvivalMode(enabled: boolean) {

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -23,6 +23,35 @@
       </div>
     </section>
 
+    <!-- Uso de IA -->
+    <section class="card p-5 mb-6">
+      <h2 class="text-headline mb-4">Uso de IA este mês</h2>
+      <div v-if="featureUsage.loading.value" class="space-y-3">
+        <div v-for="i in 4" :key="i" class="skeleton h-10 w-full" />
+      </div>
+      <div v-else-if="featureUsage.usage.value" class="space-y-4">
+        <p class="text-micro text-base-muted">
+          Período: {{ formatDate(featureUsage.usage.value.period_start) }} — {{ formatDate(featureUsage.usage.value.period_end) }}
+        </p>
+        <div v-for="(data, key) in featureUsage.usage.value.features" :key="key" class="flex items-center gap-4">
+          <p class="text-small text-base-primary w-28 shrink-0">{{ settingsFeatureLabels[key as string] }}</p>
+          <div class="flex-1">
+            <div v-if="data.limit !== null" class="h-2 rounded-full bg-surface-tertiary overflow-hidden">
+              <div
+                class="h-2 rounded-full transition-all"
+                :class="data.remaining === 0 ? 'bg-danger' : 'bg-accent-primary'"
+                :style="{ width: Math.min(100, (data.used / Math.max(1, data.limit)) * 100) + '%' }"
+              />
+            </div>
+            <div v-else class="text-micro text-success">∞ ilimitado</div>
+          </div>
+          <p class="text-micro text-base-muted w-20 text-right shrink-0">
+            {{ data.limit !== null ? `${data.used}/${data.limit}` : `${data.used} usados` }}
+          </p>
+        </div>
+      </div>
+    </section>
+
     <!-- Aparência -->
     <section class="card p-5 mb-6">
       <h2 class="text-headline mb-4">Aparência</h2>
@@ -120,7 +149,19 @@ import { Moon, Sun, LogOut } from 'lucide-vue-next'
 import type { UserSettings } from '~/types'
 
 const auth = useAuthStore()
+const featureUsage = useFeatureUsage()
 const { colorMode, set } = useColorMode()
+
+const settingsFeatureLabels: Record<string, string> = {
+  cards_ai: 'Cards IA',
+  pdf_upload: 'Uploads PDF',
+  agent_chat: 'Tirar dúvidas',
+  podcast: 'Podcasts',
+}
+
+function formatDate(d: string) {
+  return new Date(d + 'T00:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' })
+}
 const toast = useToast()
 const { $api } = useNuxtApp()
 
@@ -182,6 +223,7 @@ async function handleLogout() {
 
 onMounted(async () => {
   await loadSettings()
+  featureUsage.fetchUsage()
   if (!auth.user && auth.token) {
     try {
       const { $api } = useNuxtApp()

--- a/app/plugins/api.ts
+++ b/app/plugins/api.ts
@@ -33,6 +33,12 @@ export default defineNuxtPlugin(() => {
       if (response.status === 401 && import.meta.client) {
         await navigateTo('/login')
       }
+      if (response.status === 402 && import.meta.client) {
+        const data = response._data
+        window.dispatchEvent(new CustomEvent('feature-limit-reached', {
+          detail: { feature: data?.feature, planRequired: data?.plan_required },
+        }))
+      }
     },
   })
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -216,3 +216,16 @@ export interface AnkiImportStatus {
   stats?: { decks_created: number; cards_created: number; topics_created: number; media_extracted: number }
   error?: string
 }
+
+export interface FeatureData {
+  used: number
+  limit: number | null
+  remaining: number | null
+}
+
+export interface FeatureUsageData {
+  plan: string
+  period_start: string
+  period_end: string
+  features: Record<string, FeatureData>
+}


### PR DESCRIPTION
## Fase 3.2 — Limites por Feature + Planos (Frontend)

- Composable `useFeatureUsage`
- Badges de uso no dashboard com barras de progresso
- Seção "Uso de IA este mês" em Settings com período e barras detalhadas
- Modal de upgrade (`UpgradeModal`) com interceptação automática de 402
- Tipos `FeatureData` e `FeatureUsageData`

Build passando, 40 testes passando.

Closes #36