### PR TITLE
feat: frontend IA + RAG — geração de cards, PDFs, chat

### DIFF
--- a/app/components/agent/AiGenerateModal.vue
+++ b/app/components/agent/AiGenerateModal.vue
@@ -1,0 +1,143 @@
+<template>
+  <UiModal v-model="modelValue" size="lg" aria-label="Gerar cards com IA">
+    <div v-if="!generatedCards.length">
+      <h2 class="text-heading mb-4">Gerar cards com IA</h2>
+
+      <!-- Tabs -->
+      <div class="flex gap-2 mb-6" role="tablist">
+        <button
+          v-for="tab in tabs"
+          :key="tab.value"
+          class="px-4 py-2 rounded-lg text-small transition-colors"
+          :class="source === tab.value ? 'bg-accent-primary text-white' : 'bg-surface-tertiary text-base-muted hover:text-base-primary'"
+          role="tab"
+          :aria-selected="source === tab.value"
+          @click="source = tab.value"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <!-- Free -->
+      <div v-if="source === 'free'">
+        <label for="ai-prompt" class="text-label mb-1 block">Tema</label>
+        <input
+          id="ai-prompt"
+          v-model="prompt"
+          type="text"
+          class="input w-full"
+          placeholder="Ex: Direito Constitucional — Art. 5º"
+          maxlength="500"
+        />
+      </div>
+
+      <!-- Notes -->
+      <div v-if="source === 'notes'">
+        <label for="ai-topic" class="text-label mb-1 block">Tópico</label>
+        <select id="ai-topic" v-model="topicId" class="input w-full">
+          <option value="">Selecione um tópico</option>
+          <option v-for="t in topics" :key="t.id" :value="t.id">{{ t.name }}</option>
+        </select>
+      </div>
+
+      <!-- PDF -->
+      <div v-if="source === 'pdf'">
+        <label for="ai-doc" class="text-label mb-1 block">Documento</label>
+        <select id="ai-doc" v-model="documentId" class="input w-full">
+          <option value="">Selecione um PDF</option>
+          <option v-for="d in documents" :key="d.id" :value="d.id">{{ d.original_name }}</option>
+        </select>
+      </div>
+
+      <!-- Count -->
+      <div class="mt-4">
+        <label for="ai-count" class="text-label mb-1 block">Quantidade: {{ count }}</label>
+        <input id="ai-count" v-model.number="count" type="range" min="1" max="10" class="w-full" />
+      </div>
+
+      <!-- Actions -->
+      <div class="flex justify-end gap-3 mt-6">
+        <button class="btn-secondary" @click="$emit('update:modelValue', false)">Cancelar</button>
+        <button class="btn-primary" :disabled="loading || !canGenerate" @click="generate">
+          <span v-if="loading" class="animate-spin mr-2">⏳</span>
+          {{ loading ? 'Gerando...' : 'Gerar cards' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Review -->
+    <AgentAiReviewCards
+      v-else
+      :cards="generatedCards"
+      :deck-id="deckId"
+      @accepted="onAccepted"
+      @back="generatedCards = []"
+    />
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import type { AiGeneratedCard, Document, Topic } from '~/types'
+
+const props = defineProps<{
+  modelValue: boolean
+  deckId: string
+  topics?: Topic[]
+  documents?: Document[]
+}>()
+
+defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'created'): void }>()
+
+const { $api } = useNuxtApp()
+
+const source = ref<'free' | 'notes' | 'pdf'>('free')
+const prompt = ref('')
+const topicId = ref('')
+const documentId = ref('')
+const count = ref(5)
+const loading = ref(false)
+const generatedCards = ref<AiGeneratedCard[]>([])
+
+const tabs = [
+  { label: 'Tema livre', value: 'free' as const },
+  { label: 'A partir de notas', value: 'notes' as const },
+  { label: 'A partir de PDF', value: 'pdf' as const },
+]
+
+const canGenerate = computed(() => {
+  if (source.value === 'free') return prompt.value.trim().length > 0
+  if (source.value === 'notes') return !!topicId.value
+  if (source.value === 'pdf') return !!documentId.value
+  return false
+})
+
+async function generate() {
+  loading.value = true
+  try {
+    const body: Record<string, any> = {
+      source: source.value,
+      deck_id: props.deckId,
+      count: count.value,
+    }
+    if (source.value === 'free') body.prompt = prompt.value
+    if (source.value === 'notes') body.topic_id = topicId.value
+    if (source.value === 'pdf') body.document_id = documentId.value
+
+    const res = await $api<{ data: { cards: AiGeneratedCard[] } }>('/ai/generate-cards', {
+      method: 'POST',
+      body,
+    })
+    generatedCards.value = res.data.cards
+  } catch (e: any) {
+    useToast().error(e?.data?.message || 'Erro ao gerar cards')
+  } finally {
+    loading.value = false
+  }
+}
+
+function onAccepted() {
+  generatedCards.value = []
+  // @ts-expect-error emit from parent
+  props.modelValue && (props as any).onCreated?.()
+}
+</script>

--- a/app/components/agent/AiGenerateModal.vue
+++ b/app/components/agent/AiGenerateModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <UiModal v-model="modelValue" size="lg" aria-label="Gerar cards com IA">
+  <UiModal :model-value="modelValue" size="lg" aria-label="Gerar cards com IA" @update:model-value="$emit('update:modelValue', $event)">
     <div v-if="!generatedCards.length">
       <h2 class="text-heading mb-4">Gerar cards com IA</h2>
 

--- a/app/components/agent/AiReviewCards.vue
+++ b/app/components/agent/AiReviewCards.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-heading">Revisar cards gerados ({{ cards.length }})</h2>
+      <button class="text-small text-base-muted hover:text-base-primary" @click="$emit('back')">← Voltar</button>
+    </div>
+
+    <div class="space-y-3 max-h-[400px] overflow-y-auto">
+      <div
+        v-for="(card, i) in editableCards"
+        :key="i"
+        class="card p-4"
+        :class="card.discarded ? 'opacity-40' : ''"
+      >
+        <div class="flex justify-between items-start gap-2 mb-2">
+          <span class="text-label">Card {{ i + 1 }}</span>
+          <button
+            class="text-small"
+            :class="card.discarded ? 'text-accent-primary' : 'text-danger'"
+            @click="card.discarded = !card.discarded"
+          >
+            {{ card.discarded ? 'Restaurar' : 'Descartar' }}
+          </button>
+        </div>
+        <div v-if="!card.discarded" class="space-y-2">
+          <div>
+            <label :for="`front-${i}`" class="text-small text-base-muted">Frente</label>
+            <input :id="`front-${i}`" v-model="card.front" class="input w-full text-small" />
+          </div>
+          <div>
+            <label :for="`back-${i}`" class="text-small text-base-muted">Verso</label>
+            <input :id="`back-${i}`" v-model="card.back" class="input w-full text-small" />
+          </div>
+          <p v-if="card.source_reference" class="text-small text-base-muted italic">
+            {{ card.source_reference }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex justify-end gap-3 mt-6">
+      <button class="btn-secondary" @click="$emit('back')">Cancelar</button>
+      <button class="btn-primary" :disabled="loading || !acceptedCards.length" @click="acceptAll">
+        {{ loading ? 'Salvando...' : `Aceitar ${acceptedCards.length} cards` }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AiGeneratedCard } from '~/types'
+
+const props = defineProps<{
+  cards: AiGeneratedCard[]
+  deckId: string
+}>()
+
+const emit = defineEmits<{ (e: 'accepted'): void; (e: 'back'): void }>()
+
+const { $api } = useNuxtApp()
+const loading = ref(false)
+
+const editableCards = ref(
+  props.cards.map(c => ({ ...c, discarded: false })),
+)
+
+const acceptedCards = computed(() =>
+  editableCards.value.filter(c => !c.discarded),
+)
+
+async function acceptAll() {
+  loading.value = true
+  try {
+    await $api('/ai/accept-cards', {
+      method: 'POST',
+      body: {
+        deck_id: props.deckId,
+        cards: acceptedCards.value.map(c => ({ front: c.front, back: c.back })),
+      },
+    })
+    useToast().success(`${acceptedCards.value.length} cards adicionados!`)
+    emit('accepted')
+  } catch (e: any) {
+    useToast().error(e?.data?.message || 'Erro ao salvar cards')
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/app/components/ui/BottomNav.vue
+++ b/app/components/ui/BottomNav.vue
@@ -26,7 +26,7 @@ import {
   FolderTree,
   Network,
   BookOpen,
-  BarChart3,
+  MessageCircle,
 } from 'lucide-vue-next'
 
 const route = useRoute()
@@ -36,7 +36,7 @@ const items = [
   { label: 'Decks', to: '/decks', icon: 'decks' },
   { label: 'Grafo', to: '/graph', icon: 'graph' },
   { label: 'Revisão', to: '/review', icon: 'review' },
-  { label: 'Stats', to: '/stats', icon: 'stats' },
+  { label: 'Dúvidas', to: '/chat', icon: 'chat' },
 ]
 
 const iconMap: Record<string, any> = {
@@ -44,7 +44,7 @@ const iconMap: Record<string, any> = {
   decks: Layers,
   graph: Network,
   review: BookOpen,
-  stats: BarChart3,
+  chat: MessageCircle,
 }
 
 function getIcon(name: string) {

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -48,6 +48,8 @@ import {
   Settings,
   LogOut,
   Upload,
+  FileText,
+  MessageCircle,
 } from 'lucide-vue-next'
 
 const route = useRoute()
@@ -69,6 +71,8 @@ const items = [
   { label: 'Grafo', to: '/graph', icon: 'graph' },
   { label: 'Revisão', to: '/review', icon: 'review' },
   { label: 'Estatísticas', to: '/stats', icon: 'stats' },
+  { label: 'Meus PDFs', to: '/documents', icon: 'documents' },
+  { label: 'Tirar dúvidas', to: '/chat', icon: 'chat' },
   { label: 'Importar', to: '/import', icon: 'import' },
 ]
 
@@ -79,6 +83,8 @@ const iconMap: Record<string, any> = {
   graph: Network,
   review: BookOpen,
   stats: BarChart3,
+  documents: FileText,
+  chat: MessageCircle,
   import: Upload,
 }
 

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="flex h-[calc(100vh-64px)] lg:h-screen">
+    <!-- Sidebar conversas -->
+    <aside class="w-64 bg-surface-secondary border-r border-base flex-shrink-0 flex flex-col hidden md:flex">
+      <div class="p-4">
+        <button class="btn-primary w-full text-small" @click="chat.newConversation()">
+          <Plus :size="16" /> Nova conversa
+        </button>
+      </div>
+      <nav class="flex-1 overflow-y-auto px-2" aria-label="Conversas">
+        <div
+          v-for="conv in chat.conversations"
+          :key="conv.id"
+          class="flex items-center justify-between px-3 py-2 rounded-lg cursor-pointer mb-1 transition-colors"
+          :class="chat.currentId === conv.id ? 'bg-accent-primary/10 text-accent-primary' : 'text-base-muted hover:bg-surface-tertiary'"
+          @click="chat.loadConversation(conv.id)"
+        >
+          <span class="text-small truncate flex-1">{{ conv.title }}</span>
+          <button
+            class="text-base-muted hover:text-danger ml-2 opacity-0 group-hover:opacity-100"
+            aria-label="Deletar conversa"
+            @click.stop="chat.deleteConversation(conv.id)"
+          >
+            <Trash2 :size="14" />
+          </button>
+        </div>
+        <p v-if="!chat.conversations.length" class="text-small text-base-muted px-3 py-4">
+          Nenhuma conversa ainda
+        </p>
+      </nav>
+    </aside>
+
+    <!-- Chat area -->
+    <div class="flex-1 flex flex-col">
+      <!-- Messages -->
+      <div ref="messagesContainer" class="flex-1 overflow-y-auto p-6 space-y-4">
+        <div v-if="!chat.messages.length && !chat.loading" class="flex flex-col items-center justify-center h-full text-center">
+          <MessageCircle :size="48" class="text-base-muted mb-3" />
+          <h2 class="text-heading mb-1">Tirar dúvidas</h2>
+          <p class="text-base-muted text-small max-w-md">
+            Pergunte sobre seus materiais de estudo. A IA responde com base nos seus PDFs e notas.
+          </p>
+        </div>
+
+        <div v-if="chat.loading" class="flex justify-center py-8">
+          <div class="animate-spin text-accent-primary">⏳</div>
+        </div>
+
+        <div
+          v-for="msg in chat.messages"
+          :key="msg.id"
+          class="flex"
+          :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
+        >
+          <div
+            class="max-w-[80%] rounded-2xl px-4 py-3"
+            :class="msg.role === 'user'
+              ? 'bg-accent-primary text-white rounded-br-md'
+              : 'bg-surface-tertiary text-base-primary rounded-bl-md'"
+          >
+            <div class="text-small whitespace-pre-wrap" v-html="msg.role === 'assistant' ? renderMarkdown(msg.content) : msg.content" />
+          </div>
+        </div>
+
+        <div v-if="chat.sending" class="flex justify-start">
+          <div class="bg-surface-tertiary rounded-2xl rounded-bl-md px-4 py-3">
+            <span class="text-small text-base-muted animate-pulse">Digitando...</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Input -->
+      <div class="border-t border-base p-4">
+        <form class="flex gap-3" @submit.prevent="send">
+          <label for="chat-input" class="sr-only">Mensagem</label>
+          <input
+            id="chat-input"
+            v-model="message"
+            type="text"
+            class="input flex-1"
+            placeholder="Digite sua dúvida..."
+            maxlength="2000"
+            :disabled="chat.sending"
+          />
+          <button type="submit" class="btn-primary" :disabled="!message.trim() || chat.sending">
+            <Send :size="18" />
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Plus, Trash2, Send, MessageCircle } from 'lucide-vue-next'
+
+definePageMeta({ middleware: 'auth', layout: 'default' })
+
+const chat = useChatStore()
+const message = ref('')
+const messagesContainer = ref<HTMLElement>()
+
+function renderMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.*?)\*/g, '<em>$1</em>')
+    .replace(/`(.*?)`/g, '<code class="bg-surface-secondary px-1 rounded">$1</code>')
+    .replace(/\n/g, '<br>')
+}
+
+async function send() {
+  if (!message.value.trim() || chat.sending) return
+  const msg = message.value
+  message.value = ''
+  try {
+    await chat.sendMessage(msg)
+    nextTick(() => {
+      messagesContainer.value?.scrollTo({ top: messagesContainer.value.scrollHeight, behavior: 'smooth' })
+    })
+  } catch (e: any) {
+    useToast().error(e?.data?.message || 'Erro ao enviar mensagem')
+  }
+}
+
+// Scroll on new messages
+watch(() => chat.messages.length, () => {
+  nextTick(() => {
+    messagesContainer.value?.scrollTo({ top: messagesContainer.value.scrollHeight, behavior: 'smooth' })
+  })
+})
+
+onMounted(() => {
+  chat.fetchConversations()
+})
+</script>

--- a/app/pages/decks/[id].vue
+++ b/app/pages/decks/[id].vue
@@ -24,6 +24,9 @@
           <button class="btn-secondary" @click="showAdd = true">
             <Plus :size="18" /> Adicionar card
           </button>
+          <button class="btn-secondary" @click="showAiGenerate = true">
+            <Sparkles :size="18" /> Gerar com IA
+          </button>
           <button class="btn-secondary" @click="showEditDeck = true" aria-label="Editar deck">
             <Pencil :size="18" />
           </button>
@@ -47,6 +50,7 @@
 
       <!-- Modals -->
       <FlashcardCardFormModal v-model="showAdd" :deck-id="deckId" @created="refreshCards" />
+      <AgentAiGenerateModal v-model="showAiGenerate" :deck-id="deckId" @created="refreshCards" />
       <FlashcardCardFormModal v-if="editCard" v-model="showEditCard" :deck-id="deckId" :card="editCard" @updated="refreshCards" />
       <DeckEditModal v-model="showEditDeck" :deck="deckStore.current" @updated="deckStore.fetchDeck(deckId)" />
       <UiConfirmModal
@@ -128,7 +132,7 @@
 </template>
 
 <script setup lang="ts">
-import { Play, Plus, Pencil, Trash2 } from 'lucide-vue-next'
+import { Play, Plus, Pencil, Trash2, Sparkles } from 'lucide-vue-next'
 
 const route = useRoute()
 const router = useRouter()
@@ -193,6 +197,7 @@ function clozePreview(card: import('~/types').Flashcard): string {
 }
 
 const showAdd = ref(false)
+const showAiGenerate = ref(false)
 const showEditDeck = ref(false)
 const showDeleteDeck = ref(false)
 const showEditCard = ref(false)

--- a/app/pages/documents.vue
+++ b/app/pages/documents.vue
@@ -1,0 +1,167 @@
+<template>
+  <div class="p-6 max-w-4xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-display">Meus PDFs</h1>
+    </div>
+
+    <!-- Upload -->
+    <div
+      class="card p-8 mb-6 border-2 border-dashed border-base text-center cursor-pointer hover:border-accent-primary transition-colors"
+      @click="fileInput?.click()"
+      @dragover.prevent="dragOver = true"
+      @dragleave="dragOver = false"
+      @drop.prevent="onDrop"
+      :class="{ 'border-accent-primary bg-accent-primary/5': dragOver }"
+      role="button"
+      aria-label="Fazer upload de PDF"
+    >
+      <Upload :size="32" class="mx-auto mb-2 text-base-muted" />
+      <p class="text-base-secondary">Arraste um PDF aqui ou clique para selecionar</p>
+      <p class="text-small text-base-muted mt-1">Máximo 50MB, formato .pdf</p>
+      <input
+        ref="fileInput"
+        type="file"
+        accept=".pdf"
+        class="hidden"
+        @change="onFileSelect"
+      />
+    </div>
+
+    <!-- Upload progress -->
+    <div v-if="uploading" class="card p-4 mb-6">
+      <p class="text-small text-base-muted mb-2">Enviando {{ uploadName }}...</p>
+      <div class="w-full bg-surface-tertiary rounded-full h-2">
+        <div class="bg-accent-primary h-2 rounded-full transition-all" style="width: 100%" />
+      </div>
+    </div>
+
+    <!-- List -->
+    <div v-if="loading" class="space-y-3">
+      <div v-for="i in 3" :key="i" class="card p-4"><div class="skeleton h-6 w-48" /></div>
+    </div>
+
+    <div v-else-if="documents.length" class="space-y-3">
+      <div v-for="doc in documents" :key="doc.id" class="card p-4 flex items-center justify-between">
+        <div>
+          <p class="text-base-primary font-medium">{{ doc.original_name }}</p>
+          <div class="flex gap-3 mt-1">
+            <span class="text-small text-base-muted">{{ formatSize(doc.file_size) }}</span>
+            <span v-if="doc.pages_count" class="text-small text-base-muted">{{ doc.pages_count }} páginas</span>
+            <span v-if="doc.chunks_count" class="text-small text-base-muted">{{ doc.chunks_count }} trechos</span>
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <span
+            class="px-2 py-1 rounded text-small"
+            :class="statusClass(doc.status)"
+          >
+            {{ statusLabel(doc.status) }}
+          </span>
+          <button class="text-danger hover:text-danger/80" aria-label="Deletar documento" @click="deleteDoc(doc.id)">
+            <Trash2 :size="18" />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="card p-8 text-center">
+      <FileText :size="48" class="mx-auto mb-3 text-base-muted" />
+      <p class="text-base-secondary">Nenhum PDF enviado ainda</p>
+      <p class="text-small text-base-muted mt-1">Envie apostilas e provas para gerar cards com IA</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Upload, Trash2, FileText } from 'lucide-vue-next'
+import type { Document } from '~/types'
+
+definePageMeta({ middleware: 'auth' })
+
+const { $api } = useNuxtApp()
+
+const documents = ref<Document[]>([])
+const loading = ref(true)
+const uploading = ref(false)
+const uploadName = ref('')
+const dragOver = ref(false)
+const fileInput = ref<HTMLInputElement>()
+
+async function fetchDocuments() {
+  loading.value = true
+  try {
+    const res = await $api<{ data: Document[] }>('/documents')
+    documents.value = res.data
+  } finally {
+    loading.value = false
+  }
+}
+
+async function uploadFile(file: File) {
+  if (file.size > 50 * 1024 * 1024) {
+    useToast().error('Arquivo deve ter no máximo 50MB')
+    return
+  }
+  if (!file.name.endsWith('.pdf')) {
+    useToast().error('Apenas arquivos PDF são aceitos')
+    return
+  }
+
+  uploading.value = true
+  uploadName.value = file.name
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    await $api('/documents', { method: 'POST', body: formData })
+    useToast().success('PDF enviado! Processamento iniciado.')
+    await fetchDocuments()
+  } catch (e: any) {
+    useToast().error(e?.data?.message || 'Erro ao enviar PDF')
+  } finally {
+    uploading.value = false
+    uploadName.value = ''
+  }
+}
+
+function onFileSelect(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) uploadFile(file)
+}
+
+function onDrop(e: DragEvent) {
+  dragOver.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file) uploadFile(file)
+}
+
+async function deleteDoc(id: string) {
+  try {
+    await $api(`/documents/${id}`, { method: 'DELETE' })
+    documents.value = documents.value.filter(d => d.id !== id)
+    useToast().success('Documento removido')
+  } catch {
+    useToast().error('Erro ao remover documento')
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function statusLabel(s: string) {
+  return { pending: 'Aguardando', processing: 'Processando', completed: 'Pronto', failed: 'Erro' }[s] || s
+}
+
+function statusClass(s: string) {
+  return {
+    pending: 'bg-amber-500/10 text-amber-600',
+    processing: 'bg-blue-500/10 text-blue-600',
+    completed: 'bg-green-500/10 text-green-600',
+    failed: 'bg-red-500/10 text-red-600',
+  }[s] || ''
+}
+
+onMounted(fetchDocuments)
+</script>

--- a/app/stores/chat.ts
+++ b/app/stores/chat.ts
@@ -1,0 +1,88 @@
+import type { Conversation, ChatMessage, ChatResponse } from '~/types'
+
+export const useChatStore = defineStore('chat', {
+  state: () => ({
+    conversations: [] as Conversation[],
+    currentId: null as string | null,
+    messages: [] as ChatMessage[],
+    loading: false,
+    sending: false,
+  }),
+
+  actions: {
+    async fetchConversations() {
+      const { $api } = useNuxtApp()
+      try {
+        const res = await $api<{ data: Conversation[] }>('/chat/conversations')
+        this.conversations = res.data
+      } catch {}
+    },
+
+    async loadConversation(id: string) {
+      const { $api } = useNuxtApp()
+      this.currentId = id
+      this.loading = true
+      try {
+        const res = await $api<{ data: { id: string; title: string; messages: ChatMessage[] } }>(`/chat/conversations/${id}`)
+        this.messages = res.data.messages
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async sendMessage(message: string) {
+      const { $api } = useNuxtApp()
+      this.sending = true
+
+      // Optimistic: add user message
+      this.messages.push({
+        id: `temp-${Date.now()}`,
+        role: 'user',
+        content: message,
+        created_at: new Date().toISOString(),
+      })
+
+      try {
+        const res = await $api<{ data: ChatResponse }>('/chat', {
+          method: 'POST',
+          body: {
+            conversation_id: this.currentId,
+            message,
+          },
+        })
+
+        this.currentId = res.data.conversation_id
+
+        this.messages.push({
+          id: `msg-${Date.now()}`,
+          role: 'assistant',
+          content: res.data.message.content,
+          created_at: new Date().toISOString(),
+        })
+
+        await this.fetchConversations()
+      } catch (e: any) {
+        // Remove optimistic message on error
+        this.messages.pop()
+        throw e
+      } finally {
+        this.sending = false
+      }
+    },
+
+    async deleteConversation(id: string) {
+      const { $api } = useNuxtApp()
+      await $api(`/chat/conversations/${id}`, { method: 'DELETE' })
+      this.conversations = this.conversations.filter(c => c.id !== id)
+      if (this.currentId === id) {
+        this.currentId = null
+        this.messages = []
+      }
+    },
+
+    newConversation() {
+      this.currentId = null
+      this.messages = []
+    },
+  },
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -229,3 +229,50 @@ export interface FeatureUsageData {
   period_end: string
   features: Record<string, FeatureData>
 }
+
+// Documents (PDF)
+export interface Document {
+  id: string
+  original_name: string
+  file_size: number
+  pages_count: number | null
+  status: 'pending' | 'processing' | 'completed' | 'failed'
+  topic_id: string | null
+  chunks_count?: number
+  created_at: string
+}
+
+// AI Cards
+export interface AiGeneratedCard {
+  front: string
+  back: string
+  source_reference?: string
+}
+
+export interface AiGenerateResult {
+  cards: AiGeneratedCard[]
+  source: 'free' | 'notes' | 'pdf'
+}
+
+// Chat
+export interface Conversation {
+  id: string
+  title: string
+  messages_count: number
+  updated_at: string
+}
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  created_at: string
+}
+
+export interface ChatResponse {
+  conversation_id: string
+  message: {
+    role: 'assistant'
+    content: string
+  }
+}


### PR DESCRIPTION
## Contexto
Fase 3.3 — IA + RAG. Frontend completo (Tarefas 6-8).

Closes #38

## O que foi feito
- Tipos: Document, AiGeneratedCard, Conversation, ChatMessage
- AiGenerateModal (3 tabs: tema livre, notas, PDF) + AiReviewCards (editar/descartar/aceitar)
- Botão "Gerar com IA" na página do deck
- Página /documents (upload drag & drop, status badges, delete)
- Página /chat (sidebar conversas, mensagens com markdown, indicador "digitando")
- Store chat.ts (fetchConversations, sendMessage, deleteConversation)
- Links na sidebar (Meus PDFs, Tirar dúvidas) e bottom nav (Dúvidas)

## Build
✅ Passando