### PR TITLE
Fase 3.4: Revisão Relâmpago + Hints na Revisão

### DIFF
--- a/app/components/agent/AiGenerateModal.vue
+++ b/app/components/agent/AiGenerateModal.vue
@@ -33,9 +33,9 @@
 
       <!-- Notes -->
       <div v-if="source === 'notes'">
-        <label for="ai-topic" class="text-label mb-1 block">Tópico</label>
+        <label for="ai-topic" class="text-label mb-1 block">Caderno</label>
         <select id="ai-topic" v-model="topicId" class="input-base w-full">
-          <option value="">Selecione um tópico</option>
+          <option value="">Selecione um caderno</option>
           <option v-for="t in topics" :key="t.id" :value="t.id">{{ t.name }}</option>
         </select>
       </div>

--- a/app/components/topic/GraphOverlay.vue
+++ b/app/components/topic/GraphOverlay.vue
@@ -53,13 +53,13 @@
             </button>
           </div>
           <div v-else-if="searchQuery.trim().length >= 2 && !searchResults.length" class="mt-1 bg-surface-secondary border border-base rounded-lg shadow-lg px-3 py-2">
-            <p class="text-micro text-base-muted">Nenhum tópico encontrado</p>
+            <p class="text-micro text-base-muted">Nenhum caderno encontrado</p>
           </div>
         </div>
 
         <!-- Connect mode banner -->
         <div v-if="connectMode" class="px-4 py-2 bg-accent-primary-subtle text-accent-primary text-small text-center shrink-0">
-          {{ connectSource ? 'Clique no segundo tópico para conectar' : 'Clique no primeiro tópico' }}
+          {{ connectSource ? 'Clique no segundo caderno para conectar' : 'Clique no primeiro caderno' }}
           <span v-if="connectSource" class="font-medium"> — {{ connectSourceName }}</span>
         </div>
 
@@ -69,8 +69,8 @@
             <div class="skeleton h-64 w-64 rounded-full" />
           </div>
           <div v-else-if="!graphStore.data?.nodes.length" class="flex-1 flex flex-col items-center justify-center">
-            <p class="text-title text-base-secondary">Nenhum tópico ainda</p>
-            <p class="text-small text-base-muted mt-1">Crie tópicos para ver seu mapa.</p>
+            <p class="text-title text-base-secondary">Nenhum caderno ainda</p>
+            <p class="text-small text-base-muted mt-1">Crie cadernos para ver seu mapa.</p>
           </div>
           <div v-else ref="containerRef" class="flex-1 relative overflow-hidden min-h-[300px]" />
 
@@ -103,10 +103,10 @@
             </div>
             <div class="p-4 flex flex-col gap-2">
               <NuxtLink :to="`/review?topic_id=${graphStore.selectedNode.id}`" class="btn-primary text-small justify-center">
-                Revisar tópico
+                Revisar caderno
               </NuxtLink>
               <NuxtLink :to="`/topics?topic=${graphStore.selectedNode.id}`" class="btn-secondary text-small justify-center" @click="close">
-                Ver tópico
+                Ver caderno
               </NuxtLink>
             </div>
           </aside>
@@ -132,7 +132,7 @@
 
         <!-- Connect label modal -->
         <UiModal v-model="showLabelModal" size="sm">
-          <h2 class="text-headline mb-4">Conectar tópicos</h2>
+          <h2 class="text-headline mb-4">Conectar cadernos</h2>
           <p class="text-small text-base-secondary mb-3">{{ connectSourceName }} ↔ {{ connectTargetName }}</p>
           <input v-model="connectLabel" class="input-base" placeholder="Label (opcional)" @keydown.enter="confirmConnection" />
           <div class="flex gap-3 justify-end mt-4">

--- a/app/components/topic/Tree.vue
+++ b/app/components/topic/Tree.vue
@@ -13,7 +13,7 @@
       @add-child="$emit('add-child', $event)"
     />
     <div v-if="!topics.length" class="text-small text-base-muted px-3 py-4">
-      Nenhum tópico criado.
+      Nenhum caderno criado.
     </div>
   </div>
 </template>

--- a/app/components/topic/TreeItem.vue
+++ b/app/components/topic/TreeItem.vue
@@ -32,7 +32,7 @@
 
       <!-- Actions (visible on hover/selected) -->
       <span v-if="showActions" class="flex items-center gap-0.5 shrink-0" @click.stop>
-        <button class="p-2 rounded hover:bg-surface-tertiary" title="Adicionar sub-tópico" @click="$emit('add-child', topic.id)">
+        <button class="p-2 rounded hover:bg-surface-tertiary" title="Adicionar tópico" @click="$emit('add-child', topic.id)">
           <Plus :size="14" />
         </button>
         <button class="p-2 rounded hover:bg-surface-tertiary" title="Editar" @click="$emit('edit', topic)">

--- a/app/pages/import.vue
+++ b/app/pages/import.vue
@@ -59,7 +59,7 @@
           </div>
           <div class="bg-surface-tertiary rounded-lg p-3 text-center">
             <p class="text-title text-accent-primary">{{ store.preview.tags.length }}</p>
-            <p class="text-micro text-base-muted">Tags → Tópicos</p>
+            <p class="text-micro text-base-muted">Tags → Cadernos</p>
           </div>
           <div class="bg-surface-tertiary rounded-lg p-3 text-center">
             <p class="text-title text-accent-primary">{{ store.preview.media_count }}</p>
@@ -131,14 +131,14 @@
         </div>
         <div class="bg-surface-tertiary rounded-lg p-3">
           <p class="text-title text-accent-primary">{{ store.status.stats?.topics_created }}</p>
-          <p class="text-micro text-base-muted">Tópicos</p>
+          <p class="text-micro text-base-muted">Cadernos</p>
         </div>
         <div class="bg-surface-tertiary rounded-lg p-3">
           <p class="text-title text-accent-primary">{{ store.status.stats?.media_extracted }}</p>
           <p class="text-micro text-base-muted">Media</p>
         </div>
       </div>
-      <NuxtLink to="/topics" class="btn-primary">Ver tópicos</NuxtLink>
+      <NuxtLink to="/topics" class="btn-primary">Ver cadernos</NuxtLink>
     </div>
 
     <!-- Failed -->
@@ -168,7 +168,7 @@ const stepLabel = computed(() => {
   const step = store.status?.current_step
   const map: Record<string, string> = {
     creating_decks: 'Criando decks...',
-    creating_topics: 'Criando tópicos...',
+    creating_topics: 'Criando cadernos...',
     importing_cards: 'Importando cards...',
     extracting_media: 'Extraindo media...',
   }

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -7,6 +7,7 @@
       </NuxtLink>
       <div class="flex items-center gap-3 text-small text-base-muted">
         <span v-if="isSurvivalMode" class="px-2 py-0.5 rounded-full text-micro uppercase tracking-wide font-medium bg-warning/15 text-warning">Sobrevivência</span>
+        <span v-if="isBlitz" class="px-2 py-0.5 rounded-full text-micro uppercase tracking-wide font-medium bg-accent-primary/15 text-accent-primary">⚡ Relâmpago</span>
         <span v-if="sessionTimer > 0" class="font-mono" :class="sessionTimer <= 60 ? 'text-danger' : ''" aria-live="polite" :aria-label="`${formatTimer(sessionTimer)} restantes`">
           {{ formatTimer(sessionTimer) }}
         </span>
@@ -156,6 +157,23 @@
         </NuxtLink>
       </div>
 
+      <!-- Hints from callout blocks -->
+      <div v-if="review.hints.length" class="mt-3 w-full max-w-md space-y-2">
+        <template v-for="(hint, i) in visibleHints" :key="i">
+          <div class="p-3 rounded-lg bg-surface-secondary border border-base-muted/10 flex items-start gap-2">
+            <span class="shrink-0">{{ hintIcon(hint.type) }}</span>
+            <p class="text-small text-base-secondary">{{ hint.text }}</p>
+          </div>
+        </template>
+        <button
+          v-if="review.hints.length > 2 && !showAllHints"
+          class="text-micro text-accent-primary hover:underline"
+          @click="showAllHints = true"
+        >
+          Ver mais {{ review.hints.length - 2 }} dica{{ review.hints.length - 2 !== 1 ? 's' : '' }}
+        </button>
+      </div>
+
       <!-- Chat trigger after error -->
       <div class="flex gap-2 mt-3">
         <button
@@ -177,14 +195,14 @@
     <!-- Timer expired modal -->
     <UiModal v-model="showTimerModal" size="sm" aria-label="Tempo esgotado">
       <div class="text-center">
-        <p class="text-4xl mb-4">⏰</p>
-        <h2 class="text-title font-serif">Tempo esgotado!</h2>
+        <p class="text-4xl mb-4">{{ isBlitz ? '⚡' : '⏰' }}</p>
+        <h2 class="text-title font-serif">{{ isBlitz ? 'Revisão rápida concluída!' : 'Tempo esgotado!' }}</h2>
         <p class="text-base-muted text-small mt-2">
-          Você revisou <span class="text-accent-primary font-medium">{{ review.reviewed }}</span> card{{ review.reviewed !== 1 ? 's' : '' }}.
+          Você revisou <span class="text-accent-primary font-medium">{{ review.reviewed }}</span> card{{ review.reviewed !== 1 ? 's' : '' }}{{ isBlitz ? ' em 5 min' : '' }}.
         </p>
         <div class="flex gap-3 mt-6 justify-center">
           <NuxtLink to="/today" class="btn-secondary">Encerrar</NuxtLink>
-          <button class="btn-primary" @click="continueAfterTimer">Continuar</button>
+          <button class="btn-primary" @click="continueAfterTimer">{{ isBlitz ? 'Mais 5 min' : 'Continuar' }}</button>
         </div>
       </div>
     </UiModal>
@@ -204,7 +222,18 @@ const correctStreak = ref(0)
 const rewardMessage = ref('')
 const progressPulse = ref(false)
 const errorsByTopic = ref<Record<string, { name: string; count: number; id: string }>>({})
+const showAllHints = ref(false)
 let rewardTimeout: ReturnType<typeof setTimeout> | null = null
+
+const visibleHints = computed(() =>
+  showAllHints.value ? review.hints : review.hints.slice(0, 2),
+)
+
+function hintIcon(type: string): string {
+  if (type === 'error') return '❌'
+  if (type === 'gotcha') return '⚠️'
+  return '💡'
+}
 
 const topErrorTopic = computed(() => {
   const entries = Object.values(errorsByTopic.value).filter(e => e.count >= 2)
@@ -215,6 +244,7 @@ const topErrorTopic = computed(() => {
 async function handleRate(rating: number) {
   const cardId = review.currentCard?.id ?? ''
   const cardSnapshot = review.currentCard ? { ...review.currentCard } : null
+  showAllHints.value = false
 
   // Micro feedback
   cardFeedback.value = rating >= 3 ? 'success' : 'error'
@@ -272,15 +302,27 @@ async function loadSession() {
   const topicId = route.query.topic_id as string | undefined
   const errorsOnly = route.query.errors_only === '1'
   const backlog = route.query.backlog === '1'
+  const mode = route.query.mode as string | undefined
   if (deckId) await deckStore.fetchDeck(deckId)
-  await review.fetchSession(deckId, topicId, errorsOnly, backlog)
-  await loadSessionTimer()
+  await review.fetchSession(deckId, topicId, errorsOnly, backlog, mode)
+
+  // Blitz mode: fixed 5 min timer, ignore settings timer
+  isBlitz.value = mode === 'blitz'
+  if (isBlitz.value) {
+    sessionTimer.value = 300
+    timerInterval = setInterval(() => {
+      if (sessionTimer.value > 0) sessionTimer.value--
+    }, 1000)
+  } else {
+    await loadSessionTimer()
+  }
 }
 
 // Session timer & survival mode
 const sessionTimer = ref(0)
 const showTimerModal = ref(false)
 const isSurvivalMode = ref(false)
+const isBlitz = ref(false)
 let timerInterval: ReturnType<typeof setInterval> | null = null
 
 async function loadSessionTimer() {
@@ -308,6 +350,12 @@ watch(sessionTimer, (val, oldVal) => {
 
 function continueAfterTimer() {
   showTimerModal.value = false
+  if (isBlitz.value) {
+    sessionTimer.value = 300
+    timerInterval = setInterval(() => {
+      if (sessionTimer.value > 0) sessionTimer.value--
+    }, 1000)
+  }
 }
 
 function dismissErrorDiary() {

--- a/app/pages/review.vue
+++ b/app/pages/review.vue
@@ -119,7 +119,7 @@
       <!-- Weak connection suggestion -->
       <div v-if="review.weakSuggestion?.length && !review.showErrorDiary" class="w-full max-w-lg px-4">
         <div class="card border border-warning/30 text-center">
-          <p class="text-small text-base-muted mb-2">Tópico conectado também está fraco:</p>
+          <p class="text-small text-base-muted mb-2">Caderno conectado também está fraco:</p>
           <div v-for="w in review.weakSuggestion" :key="w.id" class="flex items-center justify-center gap-2 text-small">
             <span class="text-warning">⚠</span>
             <span class="text-base-primary font-medium">{{ w.name }}</span>
@@ -268,7 +268,7 @@ async function handleRate(rating: number) {
     if (card?.topic_id) {
       const key = card.topic_id
       if (!errorsByTopic.value[key]) {
-        errorsByTopic.value[key] = { id: card.topic_id, name: card.topic_name ?? 'Tópico', count: 0 }
+        errorsByTopic.value[key] = { id: card.topic_id, name: card.topic_name ?? 'Caderno', count: 0 }
       }
       errorsByTopic.value[key].count++
     }

--- a/app/pages/today.vue
+++ b/app/pages/today.vue
@@ -56,7 +56,10 @@
       </div>
       <div class="flex items-center justify-between">
         <span class="text-micro text-base-muted">{{ stats?.reviewed_today ?? 0 }} revisados hoje</span>
-        <NuxtLink to="/review" class="btn-primary glow-primary">Começar revisão</NuxtLink>
+        <div class="flex items-center gap-2">
+          <NuxtLink to="/review?mode=blitz" class="btn-secondary !py-2 !px-3 !min-h-[2.75rem] text-small">⚡ Rápida</NuxtLink>
+          <NuxtLink to="/review" class="btn-primary glow-primary">Começar revisão</NuxtLink>
+        </div>
       </div>
     </div>
 

--- a/app/pages/topics/index.vue
+++ b/app/pages/topics/index.vue
@@ -125,9 +125,12 @@
             <p class="text-headline text-base-primary">{{ pendingCount }} card{{ pendingCount !== 1 ? 's' : '' }} pendente{{ pendingCount !== 1 ? 's' : '' }}</p>
             <p class="text-small text-base-muted mt-1">Continue seu progresso de hoje</p>
           </div>
-          <NuxtLink :to="`/review?topic_id=${selectedTopicId}`" class="btn-primary !py-3 !px-6 shrink-0">
-            Revisar agora
-          </NuxtLink>
+          <div class="flex items-center gap-2 shrink-0">
+            <NuxtLink :to="`/review?mode=blitz&topic_id=${selectedTopicId}`" class="btn-secondary !py-3 !px-4 text-small">⚡ Rápida</NuxtLink>
+            <NuxtLink :to="`/review?topic_id=${selectedTopicId}`" class="btn-primary !py-3 !px-6">
+              Revisar agora
+            </NuxtLink>
+          </div>
         </div>
 
         <!-- Sticky header (appears on scroll) -->
@@ -237,8 +240,11 @@
     </main>
 
     <!-- Mobile: sticky bottom review button -->
-    <div v-if="selectedTopicId && dueCardsCount > 0" class="lg:hidden fixed bottom-16 left-0 right-0 p-3 bg-overlay border-t border-base z-30">
-      <NuxtLink :to="`/review?topic_id=${selectedTopicId}`" class="btn-primary w-full justify-center">
+    <div v-if="selectedTopicId && dueCardsCount > 0" class="lg:hidden fixed bottom-16 left-0 right-0 p-3 bg-overlay border-t border-base z-30 flex gap-2">
+      <NuxtLink :to="`/review?mode=blitz&topic_id=${selectedTopicId}`" class="btn-secondary flex-none justify-center !py-2.5 !px-3">
+        ⚡ Rápida
+      </NuxtLink>
+      <NuxtLink :to="`/review?topic_id=${selectedTopicId}`" class="btn-primary flex-1 justify-center">
         Revisar {{ dueCardsCount }} card{{ dueCardsCount !== 1 ? 's' : '' }}
       </NuxtLink>
     </div>

--- a/app/pages/topics/index.vue
+++ b/app/pages/topics/index.vue
@@ -274,8 +274,8 @@
 
     <UiConfirmModal
       v-model="showDeleteTopic"
-      title="Deletar tópico?"
-      message="Tópicos e notas serão deletados. Cards vinculados serão removidos."
+      title="Deletar?"
+      message="Conteúdo e notas serão deletados. Cards vinculados serão removidos."
       confirm-label="Deletar"
       @confirm="handleDeleteTopic"
     />
@@ -656,7 +656,7 @@ async function handleEditTopic() {
   if (!editTopicId.value) return
   await topicStore.update(editTopicId.value, { name: editTopicName.value })
   showEditTopic.value = false
-  toast.show('Tópico atualizado!', 'success')
+  toast.show('Salvo!', 'success')
 }
 
 async function handleDeleteTopic() {
@@ -664,7 +664,7 @@ async function handleDeleteTopic() {
   await topicStore.remove(deleteTopicId.value)
   if (selectedTopicId.value === deleteTopicId.value) selectedTopicId.value = null
   showDeleteTopic.value = false
-  toast.show('Tópico deletado.', 'success')
+  toast.show('Deletado.', 'success')
 }
 
 function extractTextFromTiptap(doc: any): string {

--- a/app/stores/review.ts
+++ b/app/stores/review.ts
@@ -18,6 +18,7 @@ export const useReviewStore = defineStore('review', {
     noteSnippet: null as { note_id: string; title: string; snippet: string; topic_id: string } | null,
     lastReviewId: null as string | null,
     showErrorDiary: false,
+    hints: [] as { type: string; text: string }[],
     _tick: 0,
     _pendingAdvance: null as (() => void) | null,
   }),
@@ -46,7 +47,7 @@ export const useReviewStore = defineStore('review', {
   },
 
   actions: {
-    async fetchSession(deckId?: string, topicId?: string, errorsOnly?: boolean, backlog?: boolean) {
+    async fetchSession(deckId?: string, topicId?: string, errorsOnly?: boolean, backlog?: boolean, mode?: string) {
       this.loading = true
       this.finished = false
       this.currentIndex = 0
@@ -54,6 +55,7 @@ export const useReviewStore = defineStore('review', {
       this.learningQueue = []
       this.weakSuggestion = null
       this.noteSnippet = null
+      this.hints = []
       this.showErrorDiary = false
       try {
         const { $api } = useNuxtApp()
@@ -62,6 +64,7 @@ export const useReviewStore = defineStore('review', {
         if (topicId) params.set('topic_id', topicId)
         if (errorsOnly) params.set('errors_only', '1')
         if (backlog) params.set('backlog', '1')
+        if (mode) params.set('mode', mode)
         const query = params.toString() ? `?${params}` : ''
         const res = await $api<any>(`/review/session${query}`)
         const allCards = res.data as SessionCard[]
@@ -103,6 +106,15 @@ export const useReviewStore = defineStore('review', {
         // Weak connection suggestion on Again
         this.weakSuggestion = res.data.weak_connections ?? null
         this.noteSnippet = res.data.note_snippet ?? null
+
+        // Fetch hints on Again/Hard
+        this.hints = []
+        if (rating <= 2 && card.source_note_id) {
+          try {
+            const hintsRes = await $api<any>(`/flashcards/${card.id}/hints`)
+            this.hints = hintsRes.data ?? []
+          } catch {}
+        }
 
         // Show error diary on Again
         this.lastReviewId = res.data.review?.id ?? null


### PR DESCRIPTION
## Resumo

Frontend da Fase 3.4:

### Revisão Relâmpago
- Botão "⚡ Rápida" no Today (ao lado de "Começar revisão") e no caderno (hero + sticky mobile)
- Timer fixo 5 min com badge "⚡ Relâmpago" no topo
- Modal de resumo: "Você revisou X cards em 5 min" + "Mais 5 min" / "Encerrar"
- Navega via `/review?mode=blitz`

### Hints na Revisão
- Após rating Again/Hard, busca `GET /flashcards/{id}/hints`
- Exibe callouts abaixo do reverse linking com ícones (❌ Erro, 💡 Insight, ⚠️ Pegadinha)
- Colapsável quando >2 hints ("Ver mais dicas")

## Build
- `npm run build` passando ✅

## Depende de
- API PR (memorai-api #44)

Closes #43