### PR TITLE
Fase 5: Podcast de Revisão

### DIFF
--- a/app/components/podcast/Player.vue
+++ b/app/components/podcast/Player.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="flex items-center gap-3 p-3 rounded-xl bg-surface-secondary">
+    <button
+      class="shrink-0 w-10 h-10 rounded-full bg-accent-primary/15 text-accent-primary flex items-center justify-center hover:bg-accent-primary/25 transition-colors"
+      :aria-label="isPlaying ? 'Pausar' : 'Reproduzir'"
+      @click="togglePlay"
+    >
+      <Pause v-if="isPlaying" :size="18" />
+      <Play v-else :size="18" class="ml-0.5" />
+    </button>
+    <div class="flex-1 min-w-0">
+      <p class="text-small text-base-primary truncate">{{ title }}</p>
+      <div class="flex items-center gap-2 mt-1">
+        <input
+          type="range"
+          min="0"
+          :max="audioDuration || 100"
+          :value="currentTime"
+          class="flex-1 h-1 accent-amber-600 cursor-pointer"
+          aria-label="Progresso do áudio"
+          @input="seek"
+        />
+        <span class="text-micro text-base-muted shrink-0">{{ formatTime(currentTime) }} / {{ formatTime(audioDuration || duration) }}</span>
+      </div>
+    </div>
+  </div>
+  <audio ref="audioEl" :src="audioUrl" preload="metadata" @timeupdate="onTimeUpdate" @loadedmetadata="onLoaded" @ended="isPlaying = false" />
+</template>
+
+<script setup lang="ts">
+import { Play, Pause } from 'lucide-vue-next'
+
+defineProps<{
+  audioUrl: string
+  title: string
+  duration: number
+}>()
+
+const audioEl = ref<HTMLAudioElement>()
+const isPlaying = ref(false)
+const currentTime = ref(0)
+const audioDuration = ref(0)
+
+function togglePlay() {
+  if (!audioEl.value) return
+  if (isPlaying.value) {
+    audioEl.value.pause()
+  } else {
+    audioEl.value.play()
+  }
+  isPlaying.value = !isPlaying.value
+}
+
+function onTimeUpdate() {
+  currentTime.value = Math.floor(audioEl.value?.currentTime ?? 0)
+}
+
+function onLoaded() {
+  audioDuration.value = Math.floor(audioEl.value?.duration ?? 0)
+}
+
+function seek(e: Event) {
+  const val = Number((e.target as HTMLInputElement).value)
+  if (audioEl.value) audioEl.value.currentTime = val
+  currentTime.value = val
+}
+
+function formatTime(s: number): string {
+  const m = Math.floor(s / 60)
+  const sec = s % 60
+  return `${m}:${sec.toString().padStart(2, '0')}`
+}
+</script>

--- a/app/components/ui/BottomNav.vue
+++ b/app/components/ui/BottomNav.vue
@@ -25,6 +25,7 @@ import {
   BookOpen,
   RotateCcw,
   BarChart3,
+  Headphones,
 } from 'lucide-vue-next'
 
 const route = useRoute()
@@ -33,6 +34,7 @@ const items = [
   { label: 'Hoje', to: '/today', icon: 'home' },
   { label: 'Cadernos', to: '/topics', icon: 'topics' },
   { label: 'Revisão', to: '/review', icon: 'review' },
+  { label: 'Podcasts', to: '/podcasts', icon: 'podcasts' },
   { label: 'Progresso', to: '/progress', icon: 'progress' },
 ]
 
@@ -40,6 +42,7 @@ const iconMap: Record<string, any> = {
   home: Home,
   topics: BookOpen,
   review: RotateCcw,
+  podcasts: Headphones,
   progress: BarChart3,
 }
 

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -43,6 +43,7 @@ import {
   BookOpen,
   RotateCcw,
   BarChart3,
+  Headphones,
   Settings,
   LogOut,
 } from 'lucide-vue-next'
@@ -63,6 +64,7 @@ const items = [
   { label: 'Hoje', to: '/today', icon: 'home' },
   { label: 'Cadernos', to: '/topics', icon: 'topics' },
   { label: 'Revisão', to: '/review', icon: 'review' },
+  { label: 'Podcasts', to: '/podcasts', icon: 'podcasts' },
   { label: 'Progresso', to: '/progress', icon: 'progress' },
 ]
 
@@ -70,6 +72,7 @@ const iconMap: Record<string, any> = {
   home: Home,
   topics: BookOpen,
   review: RotateCcw,
+  podcasts: Headphones,
   progress: BarChart3,
 }
 

--- a/app/pages/podcasts.vue
+++ b/app/pages/podcasts.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="p-4 sm:p-6 pb-20 lg:pb-6 max-w-3xl mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-display">Podcasts</h1>
+      <button
+        v-if="canGenerate"
+        class="btn-primary"
+        :disabled="store.generating || store.hasPending"
+        @click="handleGenerate"
+      >
+        <Loader2 v-if="store.generating" :size="16" class="animate-spin" />
+        <Headphones v-else :size="16" />
+        {{ store.generating ? 'Gerando...' : '🎙️ Gerar podcast' }}
+      </button>
+      <button v-else class="btn-primary" @click="showUpgrade = true">
+        🎙️ Gerar podcast
+      </button>
+    </div>
+
+    <!-- Usage counter -->
+    <p v-if="usage" class="text-micro text-base-muted -mt-4 mb-6">
+      {{ usage.used }}/{{ usage.limit }} este mês
+    </p>
+
+    <!-- Loading -->
+    <div v-if="store.loading && !store.podcasts.length" class="text-center py-12">
+      <Loader2 :size="24" class="animate-spin text-base-muted mx-auto" />
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!store.podcasts.length" class="text-center py-16">
+      <p class="text-4xl mb-4">🎧</p>
+      <p class="text-title text-base-secondary">Nenhum podcast ainda</p>
+      <p class="text-small text-base-muted mt-1">Gere seu primeiro podcast e ouça seus pontos fracos!</p>
+    </div>
+
+    <!-- Podcast list -->
+    <div v-else class="space-y-4">
+      <div v-for="podcast in store.podcasts" :key="podcast.id" class="card">
+        <!-- Generating states -->
+        <div v-if="podcast.status === 'pending' || podcast.status === 'generating_script' || podcast.status === 'generating_audio'" class="flex items-center gap-3">
+          <Loader2 :size="20" class="animate-spin text-accent-primary shrink-0" />
+          <div>
+            <p class="text-small text-base-primary">{{ podcast.title }}</p>
+            <p class="text-micro text-base-muted">{{ statusLabel(podcast.status) }}</p>
+          </div>
+        </div>
+
+        <!-- Ready -->
+        <div v-else-if="podcast.status === 'ready'">
+          <div class="flex items-center justify-between mb-2">
+            <p class="text-small text-base-primary font-medium">{{ podcast.title }}</p>
+            <span class="text-micro text-base-muted">{{ timeAgo(podcast.created_at) }}</span>
+          </div>
+          <PodcastPlayer
+            v-if="podcast.audio_url"
+            :audio-url="podcast.audio_url"
+            :title="podcast.title"
+            :duration="podcast.duration_seconds ?? 0"
+          />
+        </div>
+
+        <!-- Failed -->
+        <div v-else-if="podcast.status === 'failed'" class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <span class="px-2 py-0.5 rounded-full text-micro bg-danger/15 text-danger">Falhou</span>
+            <p class="text-small text-base-muted">{{ podcast.title }}</p>
+          </div>
+          <button class="btn-secondary !py-1.5 !px-3 !min-h-[2.75rem] text-small" @click="handleGenerate">
+            Tentar novamente
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <UiUpgradeModal v-model="showUpgrade" feature="podcast" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Headphones, Loader2 } from 'lucide-vue-next'
+
+const store = usePodcastStore()
+const auth = useAuthStore()
+const toast = useToast()
+const showUpgrade = ref(false)
+
+const canGenerate = computed(() => auth.user?.plan !== 'free')
+
+const usage = ref<{ used: number; limit: number } | null>(null)
+
+async function loadUsage() {
+  try {
+    const { $api } = useNuxtApp()
+    const res = await $api<any>('/usage')
+    const podcast = res.data.features?.podcast
+    if (podcast && podcast.limit !== null) {
+      usage.value = { used: podcast.used, limit: podcast.limit }
+    }
+  } catch {}
+}
+
+async function handleGenerate() {
+  try {
+    await store.generate()
+    toast.show('Podcast sendo gerado! Aguarde...', 'success')
+    pollInterval = store.startPolling()
+    await loadUsage()
+  } catch (e: any) {
+    const msg = e?.data?.message || e?.message || 'Erro ao gerar podcast.'
+    toast.show(msg, 'error')
+  }
+}
+
+function statusLabel(status: string): string {
+  if (status === 'pending') return 'Na fila...'
+  if (status === 'generating_script') return 'Gerando roteiro...'
+  if (status === 'generating_audio') return 'Gerando áudio...'
+  return status
+}
+
+function timeAgo(date: string): string {
+  const diff = Date.now() - new Date(date).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'agora'
+  if (mins < 60) return `${mins}min atrás`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h atrás`
+  const days = Math.floor(hours / 24)
+  return `${days}d atrás`
+}
+
+let pollInterval: ReturnType<typeof setInterval> | null = null
+
+onMounted(async () => {
+  await store.fetchPodcasts()
+  await loadUsage()
+  if (store.hasPending) {
+    pollInterval = store.startPolling()
+  }
+})
+
+onUnmounted(() => {
+  if (pollInterval) clearInterval(pollInterval)
+})
+</script>

--- a/app/pages/today.vue
+++ b/app/pages/today.vue
@@ -104,6 +104,18 @@
       </div>
     </div>
 
+    <!-- Podcast card -->
+    <div v-if="auth.user?.plan !== 'free' && (stats?.reviewed_today ?? 0) > 0" class="mt-6">
+      <NuxtLink to="/podcasts" class="card flex items-center gap-4 hover:border-accent-primary/30 transition-colors">
+        <span class="text-3xl">🎧</span>
+        <div class="flex-1">
+          <p class="text-small font-medium text-base-primary">Ouça seus pontos fracos</p>
+          <p class="text-micro text-base-muted">Gere um podcast personalizado de revisão</p>
+        </div>
+        <span class="text-accent-primary text-small">→</span>
+      </NuxtLink>
+    </div>
+
     <!-- Pra hoje (max 3 actions) -->
     <div v-if="pendingActions.length" class="mt-8">
       <p class="text-label mb-3">Pra hoje</p>

--- a/app/stores/podcast.ts
+++ b/app/stores/podcast.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+import type { Podcast } from '~/types'
+
+export const usePodcastStore = defineStore('podcast', {
+  state: () => ({
+    podcasts: [] as Podcast[],
+    loading: false,
+    generating: false,
+  }),
+
+  getters: {
+    hasPending: (state) => state.podcasts.some(p =>
+      ['pending', 'generating_script', 'generating_audio'].includes(p.status),
+    ),
+    latestReady: (state) => state.podcasts.find(p => p.status === 'ready'),
+  },
+
+  actions: {
+    async fetchPodcasts() {
+      this.loading = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>('/podcasts')
+        this.podcasts = res.data
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async generate() {
+      this.generating = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>('/podcasts', { method: 'POST' })
+        this.podcasts.unshift(res.data)
+        return res.data
+      } finally {
+        this.generating = false
+      }
+    },
+
+    startPolling() {
+      const interval = setInterval(async () => {
+        if (!this.hasPending) {
+          clearInterval(interval)
+          return
+        }
+        await this.fetchPodcasts()
+      }, 5000)
+      return interval
+    },
+  },
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -278,3 +278,16 @@ export interface ChatResponse {
     content: string
   }
 }
+
+
+// Podcast
+export interface Podcast {
+  id: string
+  title: string
+  status: 'pending' | 'generating_script' | 'generating_audio' | 'ready' | 'failed'
+  script?: string
+  audio_url?: string | null
+  duration_seconds?: number | null
+  source_data?: { topic_names?: string[]; card_count?: number; error_count?: number } | null
+  created_at: string
+}


### PR DESCRIPTION
## Resumo

Frontend do Podcast (Fase 5):

### Página `/podcasts`
- Listagem de episódios com status visual (spinner gerando, player pronto, badge falhou)
- Botão "🎙️ Gerar podcast" com contador de uso ("3/5 este mês")
- UpgradeModal pra Free
- Polling automático (5s) enquanto tem podcast pendente
- Empty state

### Player
- Componente `podcast/Player.vue`: play/pause, barra de progresso, tempo atual/total
- Player inline no card do episódio

### Navegação
- Link "Podcasts" (Headphones) na sidebar e bottom nav
- Card "🎧 Ouça seus pontos fracos" na Today (Pro/Premium com reviews)

### Store
- `podcast.ts`: fetchPodcasts, generate, startPolling, hasPending, latestReady

## Build
- `npm run build` passando ✅

## Depende de
- API PR (memorai-api #46)

Closes #45