### PR TITLE
fix(support): DOMPurify em todos os v-html — prevenção XSS

### DIFF
--- a/app/components/chat/ChatDrawer.vue
+++ b/app/components/chat/ChatDrawer.vue
@@ -72,7 +72,7 @@
           class="mx-4 mt-3 p-3 rounded-lg bg-surface-tertiary border border-base text-small"
         >
           <p class="text-micro text-base-muted mb-1">Card errado:</p>
-          <p class="text-base-primary" v-html="chat.currentContext.cardFront" />
+          <p class="text-base-primary" v-html="sanitize(chat.currentContext.cardFront)" />
         </div>
 
         <!-- Messages -->
@@ -93,7 +93,7 @@
               :class="msg.role === 'user'
                 ? 'bg-accent-primary text-white rounded-br-md'
                 : 'bg-surface-tertiary text-base-primary rounded-bl-md prose-chat'"
-              v-html="msg.role === 'assistant' ? marked.parse(msg.content) : msg.content"
+              v-html="msg.role === 'assistant' ? sanitize(marked.parse(msg.content) as string) : sanitize(msg.content)"
             />
           </div>
 
@@ -146,6 +146,8 @@ import { X, Plus, Send, MessageCircle, Clock, GraduationCap } from 'lucide-vue-n
 import { marked } from 'marked'
 
 marked.setOptions({ breaks: true })
+
+const { sanitize } = useSanitize()
 
 const chat = useChatStore()
 const message = ref('')

--- a/app/components/flashcard/Card.vue
+++ b/app/components/flashcard/Card.vue
@@ -56,6 +56,7 @@ const props = defineProps<{
 defineEmits<{ flip: [] }>()
 
 const { renderQuestion, renderAnswer } = useCloze()
+const { sanitize } = useSanitize()
 const config = useRuntimeConfig()
 const apiOrigin = config.public.apiBase.replace('/api', '')
 
@@ -73,12 +74,12 @@ const isCloze = computed(() => props.card.type === 'cloze')
 
 const displayFront = computed(() => {
   const html = isCloze.value ? renderQuestion(props.card.front, props.card.cloze_index ?? undefined) : props.card.front
-  return resolveMedia(html)
+  return sanitize(resolveMedia(html))
 })
 
 const displayBack = computed(() => {
   const html = isCloze.value ? renderAnswer(props.card.front, props.card.cloze_index ?? undefined) : props.card.back
-  return resolveMedia(html)
+  return sanitize(resolveMedia(html))
 })
 
 const currentAudio = computed(() =>

--- a/app/components/podcast/ExpandedPlayer.vue
+++ b/app/components/podcast/ExpandedPlayer.vue
@@ -86,7 +86,7 @@
                 :key="card.id"
                 class="shrink-0 w-64 p-4 rounded-xl bg-surface-secondary border border-base snap-start"
               >
-                <p class="text-small text-base-primary line-clamp-3 card-front-preview" v-html="card.front" />
+                <p class="text-small text-base-primary line-clamp-3 card-front-preview" v-html="sanitize(card.front)" />
                 <div class="flex gap-3 mt-3">
                   <NuxtLink
                     v-if="card.topic_id"
@@ -130,6 +130,7 @@
 <script setup lang="ts">
 import { Headphones, Play, Pause, RotateCcw, RotateCw, Download, X } from 'lucide-vue-next'
 
+const { sanitize } = useSanitize()
 const player = usePlayerStore()
 
 function onKeydown(e: KeyboardEvent) {

--- a/app/components/topic/AiGeneratedCards.vue
+++ b/app/components/topic/AiGeneratedCards.vue
@@ -17,7 +17,7 @@
       <div v-for="(card, i) in cards" :key="i" class="px-4 py-3 rounded-xl bg-surface-tertiary/50">
         <div>
           <p class="text-micro text-base-muted mb-0.5">Frente</p>
-          <div class="text-body text-base-primary line-clamp-2 card-front-preview" v-html="stripMedia(card.front)" />
+          <div class="text-body text-base-primary line-clamp-2 card-front-preview" v-html="sanitize(stripMedia(card.front))" />
           <div class="flex items-center gap-1.5 mt-1" v-if="hasImage(card.front) || hasCloze(card.front)">
             <span v-if="hasImage(card.front)" class="text-micro px-1.5 py-0.5 rounded bg-surface-tertiary text-base-muted">🖼 imagem</span>
             <span v-if="hasCloze(card.front)" class="text-micro px-1.5 py-0.5 rounded bg-surface-tertiary text-base-muted">[...] lacuna</span>
@@ -25,7 +25,7 @@
         </div>
         <div class="mt-1.5 pt-1.5 border-t border-base">
           <p class="text-micro text-base-muted mb-0.5">Verso</p>
-          <div class="text-small text-base-muted line-clamp-2 card-front-preview" v-html="stripMedia(card.back)" />
+          <div class="text-small text-base-muted line-clamp-2 card-front-preview" v-html="sanitize(stripMedia(card.back))" />
           <div class="flex items-center gap-1.5 mt-1" v-if="hasImage(card.back)">
             <span class="text-micro px-1.5 py-0.5 rounded bg-surface-tertiary text-base-muted">🖼 imagem</span>
           </div>
@@ -41,6 +41,8 @@
 </template>
 
 <script setup lang="ts">
+const { sanitize } = useSanitize()
+
 defineProps<{
   cards: any[]
   loading: boolean

--- a/app/components/topic/HubCardsTab.vue
+++ b/app/components/topic/HubCardsTab.vue
@@ -92,7 +92,7 @@
             {{ stateIcon(card.state) }}
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-body text-base-primary line-clamp-2 card-front-preview" v-html="card.front" />
+            <div class="text-body text-base-primary line-clamp-2 card-front-preview" v-html="sanitize(card.front)" />
             <p class="text-small text-base-muted mt-0.5">
               {{ stateLabel(card.state) }}
               <span v-if="card.source_note_id"> · {{ noteNameById(card.source_note_id) }}</span>
@@ -100,7 +100,7 @@
             <!-- Verso (expandable) -->
             <div v-if="expandedCardId === card.id" class="mt-2 pt-2 border-t border-base">
               <p class="text-micro text-base-muted mb-1">Verso</p>
-              <div class="text-small text-base-secondary card-front-preview" v-html="card.back" />
+              <div class="text-small text-base-secondary card-front-preview" v-html="sanitize(card.back)" />
             </div>
           </div>
           <div class="flex items-center gap-1 shrink-0">
@@ -146,6 +146,8 @@
 
 <script setup lang="ts">
 import { Plus, Search, Trash2, Pencil, ChevronDown, ChevronUp, Camera } from 'lucide-vue-next'
+
+const { sanitize } = useSanitize()
 
 const props = defineProps<{
   topicId: string

--- a/app/composables/useSanitize.ts
+++ b/app/composables/useSanitize.ts
@@ -1,0 +1,13 @@
+import DOMPurify from 'dompurify'
+
+export function useSanitize() {
+  function sanitize(dirty: string): string {
+    return DOMPurify.sanitize(dirty, {
+      ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'u', 'p', 'br', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'code', 'pre', 'a', 'img', 'span', 'div', 'sub', 'sup', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'hr', 'mark'],
+      ALLOWED_ATTR: ['href', 'src', 'alt', 'class', 'target', 'rel', 'width', 'height', 'style'],
+      ALLOW_DATA_ATTR: false,
+    })
+  }
+
+  return { sanitize }
+}

--- a/app/pages/cadernos/index.vue
+++ b/app/pages/cadernos/index.vue
@@ -481,9 +481,11 @@ const newCardsCount = computed(() => {
 
 const pendingCount = computed(() => dueCardsCount.value + newCardsCount.value)
 
+const { sanitize } = useSanitize()
+
 const noteContentHtml = computed(() => {
   if (!noteContent.value) return ''
-  return extractHtmlFromTiptap(noteContent.value)
+  return sanitize(extractHtmlFromTiptap(noteContent.value))
 })
 
 function extractHtmlFromTiptap(doc: any): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tiptap/vue-3": "^3.22.3",
         "@types/d3": "^7.4.3",
         "d3": "^7.9.0",
+        "dompurify": "^3.4.2",
         "lucide-vue-next": "^1.0.0",
         "marked": "^18.0.2",
         "nuxt": "^4.4.2",
@@ -29,6 +30,7 @@
       "devDependencies": {
         "@nuxt/test-utils": "^4.0.2",
         "@playwright/test": "^1.59.1",
+        "@types/dompurify": "^3.0.5",
         "@vite-pwa/nuxt": "^1.1.1",
         "@vue/test-utils": "^2.4.6",
         "happy-dom": "^20.9.0",
@@ -6114,6 +6116,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6146,7 +6158,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -8748,6 +8760,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tiptap/vue-3": "^3.22.3",
     "@types/d3": "^7.4.3",
     "d3": "^7.9.0",
+    "dompurify": "^3.4.2",
     "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.2",
     "nuxt": "^4.4.2",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@nuxt/test-utils": "^4.0.2",
     "@playwright/test": "^1.59.1",
+    "@types/dompurify": "^3.0.5",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.9.0",


### PR DESCRIPTION
## Segurança — XSS Prevention

### DOMPurify
- Instalado `dompurify` + `@types/dompurify`
- Composable `useSanitize()` com allowlist de tags/attrs seguros
- Aplicado em todos os 10 usos de `v-html`:
  - `Card.vue` (front + back)
  - `ChatDrawer.vue` (mensagens do LLM + card context)
  - `HubCardsTab.vue` (listagem de cards)
  - `AiGeneratedCards.vue` (preview de cards gerados)
  - `ExpandedPlayer.vue` (cards do podcast)
  - `cadernos/index.vue` (nota renderizada)

### Risco mitigado
- Cards importados do Anki com HTML malicioso
- Respostas do LLM com HTML/JS injetado via prompt injection

### Validação
- Build passando ✅