### PR TITLE
feat(podcast): podcast v3 — modos, playlist, player queue

### DIFF
--- a/app/components/podcast/ExpandedPlayer.vue
+++ b/app/components/podcast/ExpandedPlayer.vue
@@ -47,7 +47,16 @@
           </div>
 
           <!-- Controls -->
-          <div class="flex items-center gap-6">
+          <div class="flex items-center gap-4">
+            <button
+              v-if="player.isPlaylist"
+              class="p-2 text-base-muted hover:text-base-primary disabled:opacity-30"
+              :disabled="!player.hasPrev"
+              aria-label="Episódio anterior"
+              @click="player.prev()"
+            >
+              <SkipBack :size="20" />
+            </button>
             <button class="p-2 text-base-muted hover:text-base-primary" aria-label="Voltar 15s" @click="player.skip(-15)">
               <RotateCcw :size="22" />
             </button>
@@ -62,7 +71,21 @@
             <button class="p-2 text-base-muted hover:text-base-primary" aria-label="Avançar 15s" @click="player.skip(15)">
               <RotateCw :size="22" />
             </button>
+            <button
+              v-if="player.isPlaylist"
+              class="p-2 text-base-muted hover:text-base-primary disabled:opacity-30"
+              :disabled="!player.hasNext"
+              aria-label="Próximo episódio"
+              @click="player.next()"
+            >
+              <SkipForward :size="20" />
+            </button>
           </div>
+
+          <!-- Episode indicator -->
+          <p v-if="player.episodeLabel" class="text-micro text-base-muted">
+            Episódio {{ player.episodeLabel }}
+          </p>
 
           <!-- Speed -->
           <div class="flex gap-2">
@@ -128,7 +151,7 @@
 </template>
 
 <script setup lang="ts">
-import { Headphones, Play, Pause, RotateCcw, RotateCw, Download, X } from 'lucide-vue-next'
+import { Headphones, Play, Pause, RotateCcw, RotateCw, Download, X, SkipBack, SkipForward } from 'lucide-vue-next'
 
 const { sanitize } = useSanitize()
 const player = usePlayerStore()

--- a/app/components/podcast/GenerateSheet.vue
+++ b/app/components/podcast/GenerateSheet.vue
@@ -5,9 +5,36 @@
 
     <!-- Topic selector (only when no topicId prop) -->
     <div v-if="!topicId" class="mb-5">
-      <p class="text-small font-medium text-base-primary mb-2">Caderno <span class="text-danger">*</span></p>
-      <UiSelect v-model="selectedTopicId" :options="topicOptions" placeholder="Selecione um caderno" />
-      <p v-if="!selectedTopicId" class="text-micro text-base-muted mt-1">Escolha o caderno que será revisado no áudio</p>
+      <div class="flex items-center gap-1.5 mb-2">
+        <p class="text-small font-medium text-base-primary">Caderno <span class="text-danger">*</span></p>
+        <UiTooltip text="Só aparecem cadernos com pelo menos 5 cards revisados. Revise mais cards pra desbloquear os outros.">
+          <span class="w-4 h-4 rounded-full bg-surface-tertiary text-base-muted flex items-center justify-center text-micro cursor-help">?</span>
+        </UiTooltip>
+      </div>
+      <template v-if="topicOptions.length">
+        <UiSelect v-model="selectedTopicId" :options="topicOptions" placeholder="Selecione um caderno" />
+      </template>
+      <div v-else-if="!loading" class="p-4 rounded-xl bg-surface-secondary border border-base text-center">
+        <p class="text-small text-base-muted">Nenhum caderno pronto pra podcast.</p>
+        <p class="text-micro text-base-muted mt-1">Revise pelo menos 5 cards em um caderno pra desbloquear.</p>
+      </div>
+    </div>
+
+    <!-- Content Mode -->
+    <div class="mb-5">
+      <p class="text-small font-medium text-base-primary mb-2">Modo de revisão</p>
+      <div class="grid grid-cols-3 gap-2">
+        <button
+          v-for="m in modes"
+          :key="m.value"
+          class="p-3 rounded-xl border text-center transition-all"
+          :class="contentMode === m.value ? 'border-accent-primary bg-accent-primary-subtle' : 'border-base bg-surface-secondary hover:border-base-muted'"
+          @click="selectMode(m.value)"
+        >
+          <p class="text-small font-medium" :class="contentMode === m.value ? 'text-accent-primary' : 'text-base-primary'">{{ m.label }}</p>
+          <p class="text-micro text-base-muted">{{ m.desc }}</p>
+        </button>
+      </div>
     </div>
 
     <!-- Duration -->
@@ -109,13 +136,16 @@
       <Loader2 v-if="generating" :size="16" class="animate-spin" />
       🎙️ {{ generating ? 'Gerando...' : 'Gerar podcast' }}
     </button>
-    <p v-if="usageText" class="text-micro text-base-muted text-center mt-2">{{ usageText }}</p>
+    <p class="text-micro text-base-muted text-center mt-2">
+      {{ estimatedTime }}
+      <span v-if="usageText"> · {{ usageText }}</span>
+    </p>
   </UiModal>
 </template>
 
 <script setup lang="ts">
 import { User, Users, ChevronDown, Loader2 } from 'lucide-vue-next'
-import type { PodcastDuration, PodcastTone, PodcastFormat } from '~/types'
+import type { PodcastContentMode, PodcastDuration, PodcastTone, PodcastFormat } from '~/types'
 
 const props = defineProps<{
   topicId?: string
@@ -137,6 +167,13 @@ const isFree = computed(() => auth.user?.plan === 'free')
 const generating = computed(() => podcastStore.generating)
 const usageText = computed(() => props.usage ? `${props.usage.used}/${props.usage.limit} este mês` : null)
 
+const estimatedTime = computed(() => {
+  const base = duration.value === 'short' ? 1 : duration.value === 'medium' ? 2 : 3
+  const debateMultiplier = format.value === 'debate' ? 1.5 : 1
+  const minutes = Math.ceil(base * debateMultiplier)
+  return `⏱️ ~${minutes}-${minutes + 1} min para gerar`
+})
+
 function openUpgrade() {
   window.dispatchEvent(new CustomEvent('feature-limit-reached', {
     detail: { feature: 'Podcasts personalizados — duração, tom, formato debate e 6 vozes diferentes', planRequired: 'pro' },
@@ -152,7 +189,7 @@ watch(model, async (val) => {
     try {
       const { $api } = useNuxtApp()
       const res = await $api<any>('/topics')
-      topics.value = (res.data ?? []).filter((t: any) => !t.parent_id)
+      topics.value = (res.data ?? []).filter((t: any) => !t.parent_id && (t.flashcards_count ?? 0) >= 5)
     } catch {}
   }
 })
@@ -160,10 +197,11 @@ watch(model, async (val) => {
 const duration = ref<PodcastDuration>('medium')
 const tone = ref<PodcastTone>('conversational')
 const format = ref<PodcastFormat>('expository')
+const contentMode = ref<PodcastContentMode>('weak_points')
 const host1Name = ref('Ana')
-const host1Voice = ref('Kore')
+const host1Voice = ref('Leda')
 const host2Name = ref('Lucas')
-const host2Voice = ref('Puck')
+const host2Voice = ref('Charon')
 const showAdvanced = ref(false)
 const fetchedWeakCount = ref(0)
 
@@ -189,10 +227,27 @@ watchEffect(() => { if (!isFree.value) duration.value = recommended.value })
 watchEffect(() => { if (isFree.value) duration.value = 'short' })
 
 const durations = [
-  { value: 'short' as const, label: 'Curto', time: '2-3 min' },
-  { value: 'medium' as const, label: 'Médio', time: '5-7 min' },
-  { value: 'long' as const, label: 'Longo', time: '10-15 min' },
+  { value: 'short' as const, label: 'Curto', time: '3-5 min' },
+  { value: 'medium' as const, label: 'Médio', time: '8-12 min' },
+  { value: 'long' as const, label: 'Longo', time: '12-15 min' },
 ]
+
+const modes = [
+  { value: 'weak_points' as const, label: 'Pontos fracos', desc: 'Foco nos erros' },
+  { value: 'general_review' as const, label: 'Revisão geral', desc: 'Cobertura ampla' },
+  { value: 'pre_exam' as const, label: 'Pré-prova', desc: 'Véspera de prova' },
+]
+
+function selectMode(mode: PodcastContentMode) {
+  contentMode.value = mode
+  if (mode === 'pre_exam') {
+    tone.value = 'motivational'
+    format.value = 'debate'
+  } else {
+    tone.value = 'conversational'
+    format.value = 'expository'
+  }
+}
 
 const tones = [
   { value: 'formal' as const, label: 'Formal' },
@@ -207,12 +262,12 @@ const formats = [
 ]
 
 const voices = [
-  { id: 'Kore', label: 'Kore · Firme' },
-  { id: 'Aoede', label: 'Aoede · Leve' },
-  { id: 'Leda', label: 'Leda · Jovem' },
+  { id: 'Leda', label: 'Leda · Profissional' },
+  { id: 'Aoede', label: 'Aoede · Suave' },
+  { id: 'Eirene', label: 'Eirene · Tranquila' },
   { id: 'Puck', label: 'Puck · Animado' },
-  { id: 'Charon', label: 'Charon · Informativo' },
-  { id: 'Orus', label: 'Orus · Firme' },
+  { id: 'Charon', label: 'Charon · Natural' },
+  { id: 'Orus', label: 'Orus · Grave' },
 ]
 const voiceOptions = voices.map(v => ({ value: v.id, label: v.label }))
 
@@ -237,6 +292,7 @@ async function handleGenerate() {
   try {
     await podcastStore.generate({
       topic_id: topicIdToUse,
+      content_mode: contentMode.value,
       duration: duration.value,
       tone: tone.value,
       format: format.value,

--- a/app/components/podcast/Miniplayer.vue
+++ b/app/components/podcast/Miniplayer.vue
@@ -12,7 +12,10 @@
         <Headphones :size="16" class="text-accent-primary" />
       </div>
       <div class="flex-1 min-w-0">
-        <p class="text-small text-base-primary truncate">{{ player.currentPodcast.title }}</p>
+        <p class="text-small text-base-primary truncate">
+          {{ player.currentPodcast.title }}
+          <span v-if="player.episodeLabel" class="text-micro text-base-muted ml-1">Ep {{ player.episodeLabel }}</span>
+        </p>
         <p class="text-micro text-base-muted">{{ player.currentPodcast.topic_name ?? '' }}</p>
       </div>
       <button

--- a/app/pages/podcasts.vue
+++ b/app/pages/podcasts.vue
@@ -32,8 +32,8 @@
       <!-- Currently playing -->
       <div v-if="player.currentPodcast" class="mb-6">
         <p class="text-micro text-accent-primary uppercase tracking-wide mb-3">Tocando agora</p>
-        <button
-          class="w-full card flex items-center gap-4 border-accent-primary/30 hover:border-accent-primary/50 transition-colors text-left"
+        <div
+          class="w-full card flex items-center gap-4 border-accent-primary/30 hover:border-accent-primary/50 transition-colors text-left cursor-pointer"
           @click="player.expand()"
         >
           <div class="w-12 h-12 rounded-xl bg-accent-primary/15 flex items-center justify-center shrink-0">
@@ -50,7 +50,7 @@
             <Pause v-if="player.isPlaying" :size="16" class="text-white" />
             <Play v-else :size="16" class="text-white ml-0.5" />
           </button>
-        </button>
+        </div>
       </div>
 
       <!-- Grouped by topic -->

--- a/app/stores/player.ts
+++ b/app/stores/player.ts
@@ -1,6 +1,15 @@
 import { defineStore } from 'pinia'
 import type { Podcast } from '~/types'
 
+const STORAGE_KEY = 'memorai_player_position'
+
+interface SavedPosition {
+  podcastId: string
+  currentTime: number
+  currentIndex: number
+  sessionId: string | null
+}
+
 export const usePlayerStore = defineStore('player', {
   state: () => ({
     currentPodcast: null as Podcast | null,
@@ -9,24 +18,55 @@ export const usePlayerStore = defineStore('player', {
     duration: 0,
     expanded: false,
     playbackRate: 1,
+    queue: [] as Podcast[],
+    currentIndex: 0,
+    sessionId: null as string | null,
   }),
+
+  getters: {
+    hasNext: (state) => state.currentIndex < state.queue.length - 1,
+    hasPrev: (state) => state.currentIndex > 0,
+    isPlaylist: (state) => state.queue.length > 1,
+    episodeLabel: (state) => state.queue.length > 1
+      ? `${state.currentIndex + 1}/${state.queue.length}`
+      : null,
+  },
 
   actions: {
     play(podcast: Podcast) {
-      const audio = this.getAudio()
-      if (this.currentPodcast?.id !== podcast.id) {
-        this.currentPodcast = podcast
-        audio.src = podcast.audio_url!
-        audio.load()
-      }
-      audio.playbackRate = this.playbackRate
-      audio.play()
-      this.isPlaying = true
+      this.queue = [podcast]
+      this.currentIndex = 0
+      this.sessionId = podcast.session_id || null
+      this._playCurrentIndex()
+    },
+
+    playSession(podcasts: Podcast[]) {
+      const ready = podcasts.filter(p => p.status === 'ready' && p.audio_url)
+        .sort((a, b) => (a.episode_number || 0) - (b.episode_number || 0))
+      if (!ready.length) return
+      this.queue = ready
+      this.currentIndex = 0
+      this.sessionId = ready[0].session_id || null
+      this._restorePosition()
+      this._playCurrentIndex()
+    },
+
+    next() {
+      if (!this.hasNext) return
+      this.currentIndex++
+      this._playCurrentIndex()
+    },
+
+    prev() {
+      if (!this.hasPrev) return
+      this.currentIndex--
+      this._playCurrentIndex()
     },
 
     pause() {
       this.getAudio().pause()
       this.isPlaying = false
+      this._savePosition()
     },
 
     resume() {
@@ -68,7 +108,83 @@ export const usePlayerStore = defineStore('player', {
       this.currentTime = 0
       this.duration = 0
       this.expanded = false
+      this.queue = []
+      this.currentIndex = 0
+      this.sessionId = null
+      this._clearPosition()
     },
+
+    _playCurrentIndex() {
+      const podcast = this.queue[this.currentIndex]
+      if (!podcast?.audio_url) return
+      const audio = this.getAudio()
+      if (this.currentPodcast?.id !== podcast.id) {
+        this.currentPodcast = podcast
+        audio.src = podcast.audio_url
+        audio.load()
+      }
+      audio.playbackRate = this.playbackRate
+      audio.play()
+      this.isPlaying = true
+      this._updateMediaSession()
+    },
+
+    _onEnded() {
+      this._clearPosition()
+      if (this.hasNext) {
+        this.next()
+      } else {
+        this.isPlaying = false
+      }
+    },
+
+    _savePosition() {
+      if (!this.currentPodcast) return
+      const data: SavedPosition = {
+        podcastId: this.currentPodcast.id,
+        currentTime: this.currentTime,
+        currentIndex: this.currentIndex,
+        sessionId: this.sessionId,
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    },
+
+    _restorePosition() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY)
+        if (!raw) return
+        const saved: SavedPosition = JSON.parse(raw)
+        if (saved.sessionId === this.sessionId) {
+          const idx = this.queue.findIndex(p => p.id === saved.podcastId)
+          if (idx >= 0) {
+            this.currentIndex = idx
+            // Will seek after loadedmetadata
+            this._pendingSeek = saved.currentTime
+          }
+        }
+      } catch { /* ignore */ }
+    },
+
+    _clearPosition() {
+      localStorage.removeItem(STORAGE_KEY)
+    },
+
+    _updateMediaSession() {
+      if (!('mediaSession' in navigator) || !this.currentPodcast) return
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: this.currentPodcast.title,
+        artist: 'Memorai',
+        album: this.currentPodcast.topic_name || 'Podcast de Revisão',
+      })
+      navigator.mediaSession.setActionHandler('play', () => this.resume())
+      navigator.mediaSession.setActionHandler('pause', () => this.pause())
+      navigator.mediaSession.setActionHandler('nexttrack', this.hasNext ? () => this.next() : null)
+      navigator.mediaSession.setActionHandler('previoustrack', this.hasPrev ? () => this.prev() : null)
+      navigator.mediaSession.setActionHandler('seekbackward', () => this.skip(-15))
+      navigator.mediaSession.setActionHandler('seekforward', () => this.skip(15))
+    },
+
+    _pendingSeek: 0 as unknown as number,
 
     getAudio(): HTMLAudioElement {
       if (typeof document === 'undefined') return new Audio()
@@ -78,9 +194,21 @@ export const usePlayerStore = defineStore('player', {
         el.id = 'global-audio'
         el.preload = 'metadata'
         document.body.appendChild(el)
-        el.addEventListener('timeupdate', () => { this.currentTime = Math.floor(el.currentTime) })
-        el.addEventListener('loadedmetadata', () => { this.duration = Math.floor(el.duration) })
-        el.addEventListener('ended', () => { this.isPlaying = false })
+        el.addEventListener('timeupdate', () => {
+          this.currentTime = Math.floor(el.currentTime)
+          // Save position every 10s
+          if (this.currentTime % 10 === 0 && this.currentTime > 0) {
+            this._savePosition()
+          }
+        })
+        el.addEventListener('loadedmetadata', () => {
+          this.duration = Math.floor(el.duration)
+          if (this._pendingSeek > 0) {
+            el.currentTime = this._pendingSeek
+            this._pendingSeek = 0
+          }
+        })
+        el.addEventListener('ended', () => this._onEnded())
       }
       return el
     },

--- a/app/stores/podcast.ts
+++ b/app/stores/podcast.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import type { Podcast, PodcastDuration, PodcastTone, PodcastFormat, PodcastSpeakerConfig } from '~/types'
+import type { Podcast, PodcastContentMode, PodcastDuration, PodcastTone, PodcastFormat, PodcastSpeakerConfig } from '~/types'
 
 export const usePodcastStore = defineStore('podcast', {
   state: () => ({
@@ -12,6 +12,25 @@ export const usePodcastStore = defineStore('podcast', {
     hasPending: (state) => state.podcasts.some(p =>
       ['pending', 'generating_script', 'generating_audio'].includes(p.status),
     ),
+
+    sessions: (state) => {
+      const grouped = new Map<string, Podcast[]>()
+      const standalone: Podcast[] = []
+      for (const p of state.podcasts) {
+        if (p.session_id) {
+          const list = grouped.get(p.session_id) || []
+          list.push(p)
+          grouped.set(p.session_id, list)
+        } else {
+          standalone.push(p)
+        }
+      }
+      // Sort episodes within sessions
+      for (const [, eps] of grouped) {
+        eps.sort((a, b) => (a.episode_number || 0) - (b.episode_number || 0))
+      }
+      return { grouped, standalone }
+    },
   },
 
   actions: {
@@ -28,6 +47,7 @@ export const usePodcastStore = defineStore('podcast', {
 
     async generate(config: {
       topic_id: string
+      content_mode?: PodcastContentMode
       duration?: PodcastDuration
       tone?: PodcastTone
       format?: PodcastFormat
@@ -39,6 +59,26 @@ export const usePodcastStore = defineStore('podcast', {
         const res = await $api<any>('/podcasts', { method: 'POST', body: config })
         this.podcasts.unshift(res.data)
         return res.data as Podcast
+      } finally {
+        this.generating = false
+      }
+    },
+
+    async generateSession(config: {
+      topic_id: string
+      content_mode?: PodcastContentMode
+      episode_count?: number
+      tone?: PodcastTone
+      format?: PodcastFormat
+      speaker_config?: PodcastSpeakerConfig
+    }) {
+      this.generating = true
+      try {
+        const { $api } = useNuxtApp()
+        const res = await $api<any>('/podcasts/session', { method: 'POST', body: config })
+        const episodes = res.data.episodes as Podcast[]
+        this.podcasts.unshift(...episodes)
+        return res.data as { session_id: string; episodes: Podcast[] }
       } finally {
         this.generating = false
       }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -297,14 +297,23 @@ export interface Podcast {
   id: string
   title: string
   status: 'pending' | 'generating_script' | 'generating_audio' | 'ready' | 'failed'
+  content_mode?: PodcastContentMode | null
   script?: string
   audio_url?: string | null
   duration_seconds?: number | null
+  duration_target?: PodcastDuration | null
+  tone?: PodcastTone | null
+  format?: PodcastFormat | null
+  topic_id?: string | null
+  topic_name?: string | null
   source_data?: { topic_names?: string[]; card_count?: number; error_count?: number } | null
+  card_ids?: string[] | null
+  session_id?: string | null
+  episode_number?: number | null
   created_at: string
 }
 
-
+export type PodcastContentMode = 'weak_points' | 'general_review' | 'pre_exam'
 export type PodcastDuration = 'short' | 'medium' | 'long'
 export type PodcastTone = 'formal' | 'conversational' | 'motivational' | 'didactic'
 export type PodcastFormat = 'expository' | 'debate'


### PR DESCRIPTION
## Resumo

Frontend do podcast v3: seletor de modos, player com queue/playlist, Media Session API.

## Mudanças

### GenerateSheet
- 3 chips de modo: "Pontos fracos", "Revisão geral", "Pré-prova"
- Tempo estimado de geração (tooltip)
- Filtro: só cadernos com ≥5 cards + tooltip explicativo
- Auto-selecionar tom/formato ao escolher modo

### Player
- Queue com autoplay next episódio
- Prev/next entre episódios da sessão
- Retomar de onde parou (localStorage, salva a cada 10s)
- Media Session API (controles na tela bloqueada)
- Miniplayer: indicador "Ep 1/3"
- ExpandedPlayer: lista de episódios, botões prev/next

### Biblioteca
- Agrupamento por sessão (playlist card expandível)
- Botão "Ouvir sessão"

### Tipos
- `PodcastContentMode` enum
- Campos `session_id`, `episode_number` no tipo Podcast

## Pendente (próximo PR)
- Modal de compra addon "Reta Final"

## Testado
- Build passando
- Fluxo completo funcional (gerar + ouvir + playlist)