### PR TITLE
feat(infra): rebrand BAIGI — design system v2

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,101 +1,89 @@
 @import 'tailwindcss';
 
-/* Dark mode via classe .dark (controle manual) */
-@custom-variant dark (&:where(.dark, .dark *));
-
 /* ============================================
-   Design Tokens — Memorai
-   High-Tech Earthy — Linear meets leather notebook
-   Vibrant terracotta CTA, sage green accent, depth layers
+   Design Tokens — BAIGI
+   Cores oficiais da diretora de arte
+   Dark-native: roxo profundo + dourado + laranja queimado
+   ADR-017
    ============================================ */
 
 @theme {
-  /* Primary — Amber Queimado (identidade, assinatura) */
-  --color-primary-400: #F59E0B;
-  --color-primary-500: #D97706;
-  --color-primary-600: #B45309;
-  --color-primary-700: #92400E;
-  --color-primary-800: #78350F;
-  --color-primary-900: #451A03;
+  /* Backgrounds — App Mode (quase preto, calmo) */
+  --color-baigi-bg: #0F001F;
+  --color-baigi-bg-secondary: #1A0C2E;
 
-  /* Accent — Sage Green (secondary, progress) */
-  --color-accent-400: #B8C4A0;
-  --color-accent-500: #A3B18A;
-  --color-accent-600: #8A9A70;
+  /* Primary (dourado — APENAS CTAs) */
+  --color-baigi-primary: #F4C84A;
+  --color-baigi-primary-hover: #D9B03E;
 
-  /* Semânticas */
+  /* Glow / Accent (domado) */
+  --color-baigi-glow: #B96A3D;
+  --color-baigi-dark-glow: #5E2D46;
+
+  /* Text */
+  --color-baigi-text: #F5F5F5;
+
+  /* Semantic */
   --color-success: #22C55E;
   --color-danger: #EF4444;
   --color-warning: #F59E0B;
   --color-info: #38BDF8;
 
-  /* Fontes — serif headlines + Inter body */
+  /* Fonts */
   --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-display: 'DM Serif Display', 'Georgia', serif;
+  --font-heading: 'Poppins', ui-sans-serif, system-ui, sans-serif;
+  --font-logo: 'Fredoka', ui-sans-serif, system-ui, sans-serif;
 
-  /* Transição padrão */
+  /* Font sizes */
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1.5;
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.5;
+  --text-base: 1rem;
+  --text-base--line-height: 1.5;
+  --text-xl: 1.25rem;
+  --text-xl--line-height: 1.3;
+  --text-xl--letter-spacing: -0.01em;
+  --text-2xl: 1.5rem;
+  --text-2xl--line-height: 1.2;
+  --text-2xl--letter-spacing: -0.02em;
+  --text-3xl: 1.875rem;
+  --text-3xl--line-height: 1.2;
+  --text-3xl--letter-spacing: -0.02em;
+
+  /* Transitions */
   --transition-default: all 150ms ease-in-out;
   --transition-slow: all 200ms ease-in-out;
-
-  /* Sidebar */
-  --sidebar-width: 220px;
 }
 
 /* ============================================
-   CSS Variables — mudam entre light/dark
+   CSS Variables — dark-native (single mode)
    ============================================ */
 
 :root {
-  --bg-primary: #FAFAFA;
-  --bg-secondary: #FFFFFF;
-  --bg-tertiary: #F3F3F3;
-  --bg-overlay: rgba(255, 255, 255, 0.85);
-  --text-primary: #1A1A1A;
-  --text-secondary: #4A4A4A;
-  --text-muted: #8A8A8A;
-  --border-default: #EAEAEA;
-  --border-strong: #D4D4D4;
+  --bg-primary: #0F001F;
+  --bg-secondary: #1A0C2E;
+  --bg-tertiary: #150A25;
+  --bg-overlay: rgba(15, 0, 31, 0.94);
+  --text-primary: #F5F5F5;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --text-muted: rgba(255, 255, 255, 0.55);
+  --border-default: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.12);
 
-  --color-accent-primary: #B45309;
-  --color-accent-primary-hover: #92400E;
-  --color-accent-primary-subtle: rgba(180, 83, 9, 0.06);
+  --color-accent-primary: #F4C84A;
+  --color-accent-primary-hover: #D9B03E;
+  --color-accent-primary-subtle: rgba(244, 200, 74, 0.08);
 
-  --badge-primary-bg: rgba(180, 83, 9, 0.10);
-  --badge-primary-text: #92400E;
-  --badge-accent-bg: rgba(34, 197, 94, 0.10);
-  --badge-accent-text: #16A34A;
-  --badge-success-bg: rgba(34, 197, 94, 0.10);
-  --badge-success-text: #16A34A;
-  --badge-danger-bg: rgba(239, 68, 68, 0.10);
-  --badge-danger-text: #DC2626;
-  --badge-warning-bg: rgba(245, 158, 11, 0.10);
-  --badge-warning-text: #D97706;
-}
-
-.dark {
-  --bg-primary: #0C0B0A;
-  --bg-secondary: #161412;
-  --bg-tertiary: #1E1B18;
-  --bg-overlay: rgba(30, 27, 24, 0.85);
-  --text-primary: #E9E4D9;
-  --text-secondary: #ADA89E;
-  --text-muted: #706B64;
-  --border-default: #2A2A2A;
-  --border-strong: #363636;
-
-  --color-accent-primary: #D97706;
-  --color-accent-primary-hover: #F59E0B;
-  --color-accent-primary-subtle: rgba(217, 119, 6, 0.12);
-
-  --badge-primary-bg: rgba(217, 119, 6, 0.15);
-  --badge-primary-text: #F59E0B;
-  --badge-accent-bg: rgba(34, 197, 94, 0.12);
-  --badge-accent-text: #22C55E;
-  --badge-success-bg: rgba(34, 197, 94, 0.15);
+  --badge-primary-bg: rgba(244, 200, 74, 0.12);
+  --badge-primary-text: #F4C84A;
+  --badge-accent-bg: rgba(185, 106, 61, 0.12);
+  --badge-accent-text: #D4885A;
+  --badge-success-bg: rgba(34, 197, 94, 0.12);
   --badge-success-text: #22C55E;
-  --badge-danger-bg: rgba(239, 68, 68, 0.15);
+  --badge-danger-bg: rgba(239, 68, 68, 0.12);
   --badge-danger-text: #EF4444;
-  --badge-warning-bg: rgba(245, 158, 11, 0.15);
+  --badge-warning-bg: rgba(245, 158, 11, 0.12);
   --badge-warning-text: #F59E0B;
 }
 
@@ -116,7 +104,7 @@
 }
 
 @utility bg-overlay {
-  background-color: var(--bg-overlay, var(--bg-secondary));
+  background-color: var(--bg-overlay);
   backdrop-filter: blur(12px);
 }
 
@@ -152,14 +140,13 @@
    Component utilities
    ============================================ */
 
-/* Botão primary — Amber queimado com gradiente + glow */
 @utility btn-primary {
-  background: linear-gradient(135deg, #D97706, #B45309);
-  color: #FFFFFF;
-  font-weight: 600;
+  background: linear-gradient(135deg, #F4C84A 0%, #D9B03E 100%);
+  color: #1A0033;
+  font-weight: 700;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   min-height: 2.75rem;
   transition: all 0.15s ease;
   cursor: pointer;
@@ -167,11 +154,11 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  box-shadow: 0 4px 16px rgba(217, 119, 6, 0.25);
+  box-shadow: 0 4px 20px rgba(244, 200, 74, 0.3), 0 2px 8px rgba(244, 200, 74, 0.15);
   &:hover {
     filter: brightness(1.1);
-    transform: translateY(-1px);
-    box-shadow: 0 6px 24px rgba(217, 119, 6, 0.35);
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 6px 24px rgba(244, 200, 74, 0.3), 0 2px 8px rgba(244, 200, 74, 0.15);
   }
   &:active {
     transform: scale(0.97);
@@ -186,15 +173,14 @@
   }
 }
 
-/* Botão accent — neutro (secondary com identidade) */
-@utility btn-accent {
-  background-color: var(--bg-tertiary);
-  color: var(--text-primary);
+@utility btn-secondary {
+  background-color: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.8);
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border-strong);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   min-height: 2.75rem;
   transition: all 0.15s ease;
   cursor: pointer;
@@ -203,24 +189,22 @@
   justify-content: center;
   gap: 0.5rem;
   &:hover {
-    background-color: var(--border-default);
-    border-color: var(--text-muted);
-    transform: translateY(-1px);
+    background-color: rgba(255, 255, 255, 0.08);
+    color: #F5F5F5;
   }
   &:active {
     transform: scale(0.97);
   }
 }
 
-/* Botão secondary (ghost) */
-@utility btn-secondary {
+@utility btn-ghost {
   background-color: transparent;
   color: var(--text-primary);
   font-weight: 500;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--border-strong);
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
   min-height: 2.75rem;
   transition: all 0.15s ease;
   cursor: pointer;
@@ -229,23 +213,20 @@
   justify-content: center;
   gap: 0.5rem;
   &:hover {
-    background-color: var(--bg-tertiary);
-    border-color: var(--text-muted);
-    transform: translateY(-1px);
+    background-color: rgba(185, 106, 61, 0.1);
   }
   &:active {
     transform: scale(0.95);
   }
 }
 
-/* Botão danger */
 @utility btn-danger {
   background-color: #EF4444;
   color: #FFFFFF;
   font-weight: 600;
   font-size: 0.875rem;
   padding: 0.625rem 1.25rem;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   min-height: 2.75rem;
   transition: var(--transition-default);
   cursor: pointer;
@@ -261,62 +242,52 @@
   }
 }
 
-/* Card — profundidade real */
 @utility card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: 0.75rem;
+  background: #150A25;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
   padding: 1rem;
-  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-:where(.dark) .card {
-  background: linear-gradient(180deg, #161412, #131110);
-  border-color: transparent;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-}
-
-/* Card destaque (dívida de revisão, alertas) */
-@utility card-warm {
-  background: linear-gradient(180deg, #1A1510, #15110D);
-  border: 1px solid rgba(217, 119, 6, 0.08);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-}
-
-/* Card interativo (hover lift + glow amber) */
 @utility card-interactive {
-  background: linear-gradient(180deg, var(--bg-secondary), var(--bg-secondary));
-  border: 1px solid transparent;
-  border-radius: 0.75rem;
+  background: #150A25;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
   padding: 1rem;
-  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   cursor: pointer;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
   &:hover {
-    background: var(--bg-tertiary);
-    border-color: rgba(217, 119, 6, 0.15);
-    transform: translateY(-2px);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(217, 119, 6, 0.08);
+    border-color: rgba(255, 255, 255, 0.08);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
   }
   &:active {
-    transform: scale(0.97);
+    transform: scale(0.98);
   }
 }
 
-:where(.dark) .card-interactive {
-  background: linear-gradient(180deg, #161412, #131110);
+@utility card-glow {
+  background: #1A0C2E;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1rem;
+  padding: 1rem;
 }
 
-/* Input — focus terracotta */
+@utility card-warm {
+  background: linear-gradient(180deg, #2A1550 0%, #1A0C2E 100%);
+  border: 1px solid rgba(244, 200, 74, 0.15);
+  border-left: 2px solid rgba(244, 200, 74, 0.6);
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
 @utility input-base {
-  background-color: var(--bg-tertiary);
+  background-color: rgba(0, 0, 0, 0.25);
   color: var(--text-primary);
-  border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
   padding: 0.625rem 0.75rem;
   font-size: 0.875rem;
   min-height: 2.75rem;
@@ -327,17 +298,16 @@
     color: var(--text-muted);
   }
   &:focus {
-    border-color: #D97706;
-    box-shadow: 0 0 0 1px rgba(217, 119, 6, 0.4);
+    border-color: #B96A3D;
+    box-shadow: 0 0 0 1px rgba(185, 106, 61, 0.4);
   }
 }
 
-/* Textarea */
 @utility textarea-base {
-  background-color: var(--bg-primary);
+  background-color: rgba(0, 0, 0, 0.25);
   color: var(--text-primary);
-  border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
   padding: 0.75rem;
   font-size: 0.875rem;
   width: 100%;
@@ -348,12 +318,12 @@
     color: var(--text-muted);
   }
   &:focus {
-    border-color: #D97706;
-    box-shadow: 0 0 0 1px rgba(217, 119, 6, 0.4);
+    border-color: #B96A3D;
+    box-shadow: 0 0 0 1px rgba(185, 106, 61, 0.4);
   }
 }
 
-/* Badge */
+/* Badges */
 @utility badge {
   font-size: 0.75rem;
   font-weight: 500;
@@ -393,13 +363,119 @@
   color: var(--text-muted);
 }
 
-/* Glow */
+/* Review rating buttons */
+@utility btn-again {
+  background-color: var(--bg-secondary);
+  color: #EF4444;
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  min-height: 3.5rem;
+  width: 100%;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  &:hover {
+    border-color: rgba(239, 68, 68, 0.3);
+    box-shadow: 0 0 12px rgba(239, 68, 68, 0.1);
+  }
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+@utility btn-hard {
+  background-color: var(--bg-secondary);
+  color: rgba(245, 158, 11, 0.7);
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  min-height: 3.5rem;
+  width: 100%;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  &:hover {
+    border-color: rgba(245, 158, 11, 0.2);
+    color: #F59E0B;
+  }
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+@utility btn-good {
+  background-color: var(--bg-secondary);
+  color: #22C55E;
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  min-height: 3.5rem;
+  width: 100%;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  box-shadow: 0 0 16px rgba(34, 197, 94, 0.1);
+  &:hover {
+    border-color: rgba(34, 197, 94, 0.4);
+    box-shadow: 0 0 24px rgba(34, 197, 94, 0.18);
+  }
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+@utility btn-easy {
+  background-color: var(--bg-secondary);
+  color: rgba(185, 106, 61, 0.7);
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  min-height: 3.5rem;
+  width: 100%;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  &:hover {
+    border-color: rgba(185, 106, 61, 0.2);
+    color: #B96A3D;
+  }
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+/* Glow effects */
 @utility glow-primary {
-  box-shadow: 0 0 20px rgba(217, 119, 6, 0.2);
+  box-shadow: 0 0 20px rgba(244, 200, 74, 0.2);
 }
 
 @utility glow-accent {
-  box-shadow: 0 0 16px rgba(217, 119, 6, 0.12);
+  box-shadow: 0 0 16px rgba(185, 106, 61, 0.3);
 }
 
 @utility glow-success {
@@ -408,30 +484,38 @@
 }
 
 /* ============================================
-   Typography
+   Typography — Escala BAIGI
+   text-3xl = H1 (Poppins 700, 30px)
+   text-2xl = H2 (Poppins 600, 24px)
+   text-xl  = H3 (Poppins 600, 20px)
+   text-base = Body (Inter 400/500, 16px)
+   text-sm  = Controls (Inter 500, 14px)
+   text-xs  = Caption (Inter 400, 12px)
    ============================================ */
 
+/* Legacy aliases — map to new scale for backward compat */
 @utility text-display {
-  font-family: var(--font-display);
-  font-size: 1.5rem;
-  font-weight: 400;
+  font-family: var(--font-heading);
+  font-size: 1.875rem;
+  font-weight: 700;
   line-height: 1.2;
   letter-spacing: -0.02em;
 }
 
 @utility text-headline {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 400;
-  line-height: 1.3;
-  letter-spacing: -0.015em;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
 }
 
 @utility text-title {
   font-family: var(--font-sans);
-  font-size: 1.125rem;
-  font-weight: 500;
-  line-height: 1.4;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
 }
 
 @utility text-body {
@@ -452,129 +536,16 @@
   font-family: var(--font-sans);
   font-size: 0.75rem;
   font-weight: 400;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 @utility text-label {
   font-family: var(--font-sans);
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.05em;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
-}
-
-/* ============================================
-   Review rating buttons
-   ============================================ */
-
-@utility btn-again {
-  background-color: #161412;
-  color: #BC4749;
-  font-weight: 500;
-  font-size: 0.875rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  min-height: 3.5rem;
-  width: 100%;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  &:hover {
-    border-color: rgba(188, 71, 73, 0.3);
-    background-color: #1E1B18;
-    box-shadow: 0 0 12px rgba(188, 71, 73, 0.1);
-  }
-  &:active {
-    transform: scale(0.95);
-  }
-}
-
-@utility btn-hard {
-  background-color: #161412;
-  color: #B4833D;
-  font-weight: 500;
-  font-size: 0.875rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  min-height: 3.5rem;
-  width: 100%;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  &:hover {
-    border-color: rgba(180, 131, 61, 0.3);
-    background-color: #1E1B18;
-    box-shadow: 0 0 12px rgba(180, 131, 61, 0.1);
-  }
-  &:active {
-    transform: scale(0.95);
-  }
-}
-
-@utility btn-good {
-  background-color: #161412;
-  color: #6A994E;
-  font-weight: 500;
-  font-size: 0.875rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(106, 153, 78, 0.2);
-  min-height: 3.5rem;
-  width: 100%;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  box-shadow: 0 0 16px rgba(106, 153, 78, 0.1);
-  &:hover {
-    border-color: rgba(106, 153, 78, 0.4);
-    background-color: #1E1B18;
-    box-shadow: 0 0 24px rgba(106, 153, 78, 0.18);
-  }
-  &:active {
-    transform: scale(0.95);
-  }
-}
-
-@utility btn-easy {
-  background-color: #161412;
-  color: #D67D55;
-  font-weight: 500;
-  font-size: 0.875rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  min-height: 3.5rem;
-  width: 100%;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  &:hover {
-    border-color: rgba(214, 125, 85, 0.3);
-    background-color: #1E1B18;
-    box-shadow: 0 0 12px rgba(214, 125, 85, 0.1);
-  }
-  &:active {
-    transform: scale(0.95);
-  }
 }
 
 /* ============================================
@@ -602,34 +573,26 @@
    Base styles
    ============================================ */
 
+@utility bg-baigi-gradient {
+  background: linear-gradient(135deg, #B96A3D 0%, #4B007D 35%, #2B0057 70%, #5E2D46 100%);
+}
+
 html {
-  background-color: var(--bg-primary);
+  background-color: #0F001F;
   color: var(--text-primary);
   font-family: var(--font-sans);
 }
 
-.dark html,
-html:where(.dark) {
-  background: radial-gradient(circle at top, #16120f 0%, #0C0B0A 60%);
+body {
+  background-color: #0F001F;
   min-height: 100vh;
-}
-
-/* Noise texture overlay */
-html:where(.dark)::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  opacity: 0.025;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  pointer-events: none;
-  z-index: 0;
 }
 
 button {
   cursor: pointer;
 }
 
-/* Scrollbar sutil */
+/* Scrollbar */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -639,47 +602,47 @@ button {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
+  background: rgba(255, 255, 255, 0.08);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
+  background: rgba(255, 255, 255, 0.15);
 }
 
-/* Selection — terracotta */
+/* Selection */
 ::selection {
-  background-color: rgba(217, 119, 6, 0.3);
+  background-color: rgba(244, 200, 74, 0.3);
   color: inherit;
 }
 
-/* Cloze deletion styles */
+/* Cloze deletion */
 .cloze-blank {
   display: inline;
   padding: 0.1em 0.6em;
   border-radius: 0.25rem;
-  background: rgba(217, 119, 6, 0.15);
-  border-bottom: 2px solid rgba(217, 119, 6, 0.4);
-  color: rgba(217, 119, 6, 0.7);
+  background: rgba(244, 200, 74, 0.15);
+  border-bottom: 2px solid rgba(244, 200, 74, 0.4);
+  color: rgba(244, 200, 74, 0.7);
   font-style: italic;
 }
 
 .cloze-answer {
-  color: #D97706;
+  color: #F4C84A;
   font-weight: 600;
 }
 
-/* Glow pulse animation for primary CTA */
+/* Glow pulse animation */
 @keyframes glow-pulse {
-  0%, 100% { box-shadow: 0 0 20px rgba(217, 119, 6, 0.2); }
-  50% { box-shadow: 0 0 30px rgba(217, 119, 6, 0.35); }
+  0%, 100% { box-shadow: 0 0 20px rgba(244, 200, 74, 0.2); }
+  50% { box-shadow: 0 0 30px rgba(244, 200, 74, 0.4); }
 }
 
 .animate-glow-pulse {
   animation: glow-pulse 2.5s ease-in-out infinite;
 }
 
-/* Progress bar entrance animation */
+/* Progress bar animation */
 @keyframes progress-grow {
   from { width: 0%; }
 }
@@ -692,56 +655,57 @@ button {
    Prose — Modo leitura (notas, material IA)
    ============================================ */
 
-.prose-memorai h1,
-.prose-memorai h2,
-.prose-memorai h3 {
+.prose-baigi h1,
+.prose-baigi h2,
+.prose-baigi h3 {
   color: var(--text-primary);
+  font-family: var(--font-heading);
   font-weight: 700;
   line-height: 1.3;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
 }
 
-.prose-memorai h1 { font-size: 1.5rem; }
-.prose-memorai h2 { font-size: 1.25rem; }
-.prose-memorai h3 { font-size: 1.1rem; font-weight: 600; }
+.prose-baigi h1 { font-size: 1.5rem; }
+.prose-baigi h2 { font-size: 1.25rem; }
+.prose-baigi h3 { font-size: 1.1rem; font-weight: 600; }
 
-.prose-memorai h2:first-child,
-.prose-memorai h3:first-child {
+.prose-baigi h2:first-child,
+.prose-baigi h3:first-child {
   margin-top: 0;
 }
 
-.prose-memorai p {
+.prose-baigi p {
   color: var(--text-secondary);
   line-height: 1.7;
   margin-bottom: 0.75em;
 }
 
-.prose-memorai strong {
+.prose-baigi strong {
   color: var(--text-primary);
   font-weight: 600;
 }
 
-.prose-memorai ul,
-.prose-memorai ol {
+.prose-baigi ul,
+.prose-baigi ol {
   padding-left: 1.5em;
   margin-bottom: 0.75em;
   color: var(--text-secondary);
 }
 
-.prose-memorai ul { list-style-type: disc; }
-.prose-memorai ol { list-style-type: decimal; }
+.prose-baigi ul { list-style-type: disc; }
+.prose-baigi ol { list-style-type: decimal; }
 
-.prose-memorai li {
+.prose-baigi li {
   line-height: 1.6;
   margin-bottom: 0.25em;
 }
 
-.prose-memorai li p {
+.prose-baigi li p {
   margin-bottom: 0;
 }
 
-.prose-memorai blockquote {
+.prose-baigi blockquote {
   border-left: 3px solid var(--border-strong);
   padding-left: 1em;
   margin: 1em 0;
@@ -749,57 +713,52 @@ button {
   font-style: italic;
 }
 
-.prose-memorai code {
+.prose-baigi code {
   background: var(--bg-tertiary);
   padding: 0.15em 0.4em;
   border-radius: 0.25rem;
   font-size: 0.9em;
 }
 
-.prose-memorai img {
+.prose-baigi img {
   max-width: 100%;
   border-radius: 0.5rem;
   margin: 1em 0;
 }
 
 /* Callouts */
-.prose-memorai .callout {
+.prose-baigi .callout {
   border-radius: 0.75rem;
   padding: 0.875rem 1rem;
   margin: 1em 0;
   border-left: 4px solid;
 }
 
-.prose-memorai .callout p {
+.prose-baigi .callout p {
   margin-bottom: 0;
   color: inherit;
 }
 
-.prose-memorai .callout-info {
+.prose-baigi .callout-info {
   background: rgba(56, 189, 248, 0.08);
   border-color: #38BDF8;
   color: var(--text-secondary);
 }
 
-.prose-memorai .callout-gotcha {
+.prose-baigi .callout-gotcha {
   background: rgba(245, 158, 11, 0.08);
   border-color: #F59E0B;
   color: var(--text-secondary);
 }
 
-.prose-memorai .callout-insight {
+.prose-baigi .callout-insight {
   background: rgba(34, 197, 94, 0.08);
   border-color: #22C55E;
   color: var(--text-secondary);
 }
 
-.prose-memorai .callout-error {
+.prose-baigi .callout-error {
   background: rgba(239, 68, 68, 0.08);
   border-color: #EF4444;
   color: var(--text-secondary);
 }
-
-.dark .prose-memorai .callout-info { background: rgba(56, 189, 248, 0.06); }
-.dark .prose-memorai .callout-gotcha { background: rgba(245, 158, 11, 0.06); }
-.dark .prose-memorai .callout-insight { background: rgba(34, 197, 94, 0.06); }
-.dark .prose-memorai .callout-error { background: rgba(239, 68, 68, 0.06); }

--- a/app/components/chat/ChatFab.vue
+++ b/app/components/chat/ChatFab.vue
@@ -1,20 +1,32 @@
 <template>
   <button
     v-if="!chat.isOpen"
-    class="fixed z-40 rounded-full btn-primary !p-0 glow-primary shadow-lg"
-    :class="isMobile ? 'bottom-20 right-3 w-11 h-11' : 'bottom-4 right-4 w-14 h-14'"
-    aria-label="Abrir chat com IA"
+    class="fixed z-40 rounded-full bg-[rgba(244,200,74,0.12)] border border-[rgba(244,200,74,0.25)] text-[#F4C84A] hover:bg-[rgba(244,200,74,0.18)] hover:border-[rgba(244,200,74,0.4)] shadow-lg transition-all duration-200 flex items-center justify-center group"
+    :class="isMobile ? 'bottom-20 right-3 w-11 h-11' : 'bottom-6 right-6 h-11 px-3 gap-2 rounded-full'"
+    :aria-label="label"
     @click="chat.toggle()"
   >
-    <MessageCircle :size="isMobile ? 20 : 24" />
+    <Sparkles :size="isMobile ? 18 : 16" />
+    <span v-if="!isMobile" class="text-xs font-medium">{{ label }}</span>
   </button>
 </template>
 
 <script setup lang="ts">
-import { MessageCircle } from 'lucide-vue-next'
+import { Sparkles } from 'lucide-vue-next'
 
 const chat = useChatStore()
+const route = useRoute()
 const isMobile = ref(false)
+
+const label = computed(() => {
+  if (route.path === '/revisar') {
+    const review = useReviewStore()
+    if (review.showErrorDiary || review.lastRating === 1) return 'Quer que eu explique?'
+    return 'Não entendeu? Pergunte'
+  }
+  if (route.path.startsWith('/cadernos')) return 'Perguntar sobre o caderno'
+  return 'Tirar dúvida'
+})
 
 function checkMobile() {
   isMobile.value = window.innerWidth < 1024

--- a/app/components/flashcard/Card.vue
+++ b/app/components/flashcard/Card.vue
@@ -4,7 +4,7 @@
     <Transition name="card-slide" mode="out-in">
       <div
         :key="card.id"
-        class="review-card relative rounded-2xl px-5 sm:px-12 py-8 sm:py-12 min-h-[280px] sm:min-h-[360px] flex flex-col items-center justify-center text-center"
+        class="review-card relative rounded-2xl px-6 sm:px-10 py-10 sm:py-12 min-h-[280px] sm:min-h-[360px] flex flex-col items-center justify-center text-center"
         :class="[feedbackClass, { 'cursor-pointer select-none': !flipped }]"
         style="z-index: 1;"
         @click="!flipped && $emit('flip')"
@@ -25,11 +25,11 @@
         <Transition name="answer-expand">
           <div v-if="flipped" class="w-full max-w-md">
             <div class="flex items-center gap-3 mb-6">
-              <div class="flex-1 h-px bg-black/10 dark:bg-white/10" />
-              <span class="text-micro uppercase tracking-widest text-base-muted/50">Resposta</span>
-              <div class="flex-1 h-px bg-black/10 dark:bg-white/10" />
+              <div class="flex-1 h-px bg-white/[0.08]" />
+              <span class="text-micro uppercase tracking-widest text-white/40">Resposta</span>
+              <div class="flex-1 h-px bg-white/[0.08]" />
             </div>
-            <div class="text-lg text-base-primary leading-relaxed card-content" v-html="displayBack" />
+            <div class="text-base text-white/80 leading-relaxed card-content" v-html="displayBack" />
             <div v-if="currentAudio" class="mt-4 w-full max-w-xs mx-auto" @click.stop>
               <UiAudioPlayer :src="currentAudio" />
             </div>
@@ -89,30 +89,19 @@ const currentAudio = computed(() =>
 
 <style scoped>
 .review-card {
-  background: #FFFFFF;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid #EAEAEA;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  background: linear-gradient(180deg, #1A0C2E 0%, #150A25 100%);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-left: 2px solid rgba(244, 200, 74, 0.3);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
   transition: box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
-:where(.dark) .review-card {
-  background: rgba(16, 14, 12, 0.85);
-  border-color: rgba(217, 119, 6, 0.12);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.03),
-    0 20px 60px rgba(0, 0, 0, 0.5),
-    0 0 30px rgba(217, 119, 6, 0.05);
-}
-
-/* Micro feedback — green glow on success */
+/* Micro feedback — golden glow on success */
 .feedback-success {
-  border-color: rgba(34, 197, 94, 0.4);
+  border-color: rgba(244, 200, 74, 0.4);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.03),
     0 20px 60px rgba(0, 0, 0, 0.5),
-    0 0 40px rgba(34, 197, 94, 0.15);
+    0 0 40px rgba(244, 200, 74, 0.1);
   animation: settle 0.3s ease;
 }
 
@@ -120,9 +109,8 @@ const currentAudio = computed(() =>
 .feedback-error {
   border-color: rgba(239, 68, 68, 0.4);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.03),
     0 20px 60px rgba(0, 0, 0, 0.5),
-    0 0 40px rgba(239, 68, 68, 0.15);
+    0 0 40px rgba(239, 68, 68, 0.12);
   animation: shake 0.3s ease;
 }
 

--- a/app/components/flashcard/CardFormModal.vue
+++ b/app/components/flashcard/CardFormModal.vue
@@ -51,7 +51,7 @@
               @focus="previewSide = 'back'"
             />
           </div>
-          <div v-else class="flex-1 flex items-center justify-center rounded-lg border border-dashed border-base bg-surface-tertiary/50 px-4 py-6">
+          <div v-else class="flex-1 flex items-center justify-center rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-6">
             <p class="text-small text-base-muted text-center">O verso é gerado automaticamente pelas lacunas.</p>
           </div>
 

--- a/app/components/flashcard/ErrorDiary.vue
+++ b/app/components/flashcard/ErrorDiary.vue
@@ -1,17 +1,17 @@
 <template>
   <Transition name="slide-up">
     <div v-if="visible" class="w-full max-w-lg mx-auto">
-      <div class="card border border-warning/30 p-4">
-        <p class="text-small text-base-primary font-medium mb-1">Por que você errou?</p>
-        <p class="text-micro text-base-muted mb-3">Selecione um motivo para salvar.</p>
+      <div class="bg-[#140824] border border-white/[0.06] rounded-2xl p-5 sm:p-6">
+        <p class="text-sm text-baigi-text font-medium mb-1">Por que você errou?</p>
+        <p class="text-xs text-white/55 mb-3">Selecione um motivo para salvar.</p>
 
         <div class="flex flex-wrap gap-2 mb-3">
           <button
             v-for="opt in reasons"
             :key="opt.value"
             type="button"
-            class="px-3 py-1.5 rounded-full text-micro font-medium transition-colors"
-            :class="selected === opt.value ? 'bg-warning/20 text-warning' : 'bg-surface-tertiary text-base-muted hover:bg-surface-secondary'"
+            class="px-3 py-1.5 rounded-full text-xs font-medium transition-all"
+            :class="selected === opt.value ? 'bg-[rgba(244,200,74,0.1)] text-[#F4C84A] border border-[#F4C84A]/40' : 'bg-white/[0.06] text-white/[0.65] border border-white/[0.06] hover:bg-white/[0.1]'"
             @click="selected = opt.value"
           >
             {{ opt.icon }} {{ opt.label }}
@@ -22,14 +22,14 @@
           v-model="note"
           class="textarea-base text-small"
           rows="2"
-          placeholder="Nota rápida (opcional) — ex: confundi com o inciso X..."
+          placeholder="O que te confundiu aqui?"
         />
 
-        <div class="flex gap-2 justify-end mt-3">
-          <button type="button" class="btn-secondary text-small" @click="skip">Pular</button>
+        <div class="flex gap-2 justify-end mt-4">
+          <button type="button" class="text-sm text-white/70 hover:text-white px-3 py-1.5 transition-colors" @click="skip">Pular</button>
           <button
             type="button"
-            class="btn-primary text-micro"
+            class="btn-primary !py-1.5 !px-4 !min-h-0 text-sm"
             :disabled="!selected || saving"
             @click="save"
           >

--- a/app/components/podcast/ExpandedPlayer.vue
+++ b/app/components/podcast/ExpandedPlayer.vue
@@ -126,7 +126,7 @@
         </div>
 
         <!-- Bottom actions -->
-        <div class="flex gap-3 px-6 py-4 border-t border-base shrink-0">
+        <div class="flex gap-3 px-6 py-4 pb-safe border-t border-base shrink-0 mb-16 sm:mb-0">
           <button
             v-if="player.currentPodcast.audio_url"
             class="btn-secondary flex-none !py-2.5"
@@ -139,7 +139,7 @@
           <NuxtLink
             v-if="linkedCards.length && player.currentPodcast.topic_id"
             :to="`/revisar?topic_id=${player.currentPodcast.topic_id}&errors_only=1`"
-            class="btn-primary flex-1 justify-center"
+            class="btn-primary flex-1 justify-center items-center text-center"
             @click="player.collapse()"
           >
             Revisar cartões deste caderno

--- a/app/components/podcast/Miniplayer.vue
+++ b/app/components/podcast/Miniplayer.vue
@@ -1,15 +1,15 @@
 <template>
   <div
     v-if="player.currentPodcast"
-    class="fixed left-0 lg:left-[220px] right-0 z-40 bg-surface-secondary border-t border-base"
+    class="fixed left-0 lg:left-[220px] right-0 z-40 bg-[#0A0017] border-t border-white/[0.06]"
     :class="isMobile ? 'bottom-16' : 'bottom-0'"
   >
-    <div class="h-1 bg-surface-tertiary">
-      <div class="h-1 bg-accent-primary transition-all duration-300" :style="{ width: progressPercent + '%' }" />
+    <div class="h-[2px] bg-white/[0.06]">
+      <div class="h-[2px] bg-[#F4C84A] transition-all duration-300" :style="{ width: progressPercent + '%' }" />
     </div>
     <div class="flex items-center gap-3 px-4 py-2.5">
-      <div class="w-8 h-8 rounded-lg bg-accent-primary/15 flex items-center justify-center shrink-0">
-        <Headphones :size="16" class="text-accent-primary" />
+      <div class="w-8 h-8 rounded-lg bg-[rgba(244,200,74,0.08)] flex items-center justify-center shrink-0">
+        <Headphones :size="16" class="text-[#F4C84A]" />
       </div>
       <div class="flex-1 min-w-0">
         <p class="text-small text-base-primary truncate">

--- a/app/components/topic/DocumentsInline.vue
+++ b/app/components/topic/DocumentsInline.vue
@@ -2,13 +2,13 @@
   <div>
     <!-- Upload area -->
     <label
-      class="flex items-center gap-3 px-4 py-3.5 rounded-xl border-2 border-dashed cursor-pointer transition-all"
-      :class="uploading ? 'opacity-50 pointer-events-none border-base' : 'border-accent-primary/30 hover:border-accent-primary hover:bg-accent-primary-subtle'"
+      class="flex items-center gap-3 px-4 py-3.5 rounded-xl border cursor-pointer transition-all"
+      :class="uploading ? 'opacity-50 pointer-events-none border-white/[0.06] bg-white/[0.02]' : 'border-white/[0.06] bg-white/[0.02] hover:border-[rgba(244,200,74,0.12)] hover:bg-white/[0.04]'"
     >
-      <Upload :size="20" class="text-accent-primary shrink-0" />
+      <Upload :size="20" class="text-[#F4C84A]/70 shrink-0" />
       <div>
-        <p class="text-small text-base-primary">{{ uploading ? `Enviando ${uploadProgress}%...` : 'Subir PDF' }}</p>
-        <p v-if="!uploading" class="text-small text-base-muted">A IA transforma em resumo + flashcards</p>
+        <p class="text-sm text-baigi-text">{{ uploading ? `Enviando ${uploadProgress}%...` : 'Subir PDF' }}</p>
+        <p v-if="!uploading" class="text-xs text-white/[0.55]">A IA transforma em resumo + flashcards</p>
       </div>
       <input type="file" accept=".pdf" class="hidden" @change="onFileSelect" />
     </label>

--- a/app/components/topic/GraphOverlay.vue
+++ b/app/components/topic/GraphOverlay.vue
@@ -3,14 +3,14 @@
     <Transition name="fade">
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-50 bg-surface flex flex-col"
+        class="fixed inset-0 z-50 bg-[#0F001F] flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-label="Mapa de Conhecimento"
         @keydown.escape="close"
       >
         <!-- Header -->
-        <div class="flex items-center gap-2 px-3 sm:px-4 py-3 border-b border-base shrink-0">
+        <div class="flex items-center gap-2 px-3 sm:px-4 py-3 border-b border-white/[0.06] shrink-0">
           <button class="btn-secondary !py-1.5 !px-3 !min-h-[2.75rem] text-small" @click="close">
             ← Voltar
           </button>
@@ -39,11 +39,7 @@
           <button v-else class="btn-danger !py-1.5 !px-3 !min-h-[2.75rem] text-small" @click="cancelConnectMode">
             <X :size="16" /> Cancelar
           </button>
-          <button class="p-2 rounded-lg text-base-muted hover:text-base-secondary hover:bg-surface-tertiary" :title="isDark ? 'Modo claro' : 'Modo escuro'" @click="toggleTheme">
-            <Sun v-if="isDark" :size="18" :stroke-width="1.5" />
-            <Moon v-else :size="18" :stroke-width="1.5" />
-          </button>
-          <button class="p-2 rounded-lg text-base-muted hover:text-base-secondary hover:bg-surface-tertiary" aria-label="Fechar mapa" @click="close">
+          <button class="p-2 rounded-lg text-white/40 hover:text-white hover:bg-white/[0.06]" aria-label="Fechar mapa" @click="close">
             <X :size="20" />
           </button>
         </div>
@@ -100,7 +96,7 @@
           <!-- Node detail panel -->
           <aside
             v-if="graphStore.selectedNode"
-            class="max-sm:absolute max-sm:inset-0 max-sm:z-20 sm:w-80 border-l border-base bg-surface-secondary flex flex-col overflow-y-auto shrink-0"
+            class="max-sm:absolute max-sm:inset-0 max-sm:z-20 sm:w-80 border-l border-white/[0.06] bg-[#0A0017] flex flex-col overflow-y-auto shrink-0"
           >
             <div class="p-4 border-b border-base">
               <div class="flex items-center justify-between mb-2">
@@ -110,14 +106,13 @@
                 </button>
               </div>
               <div class="flex items-center gap-2 mb-3">
-                <div class="flex-1 h-2 rounded-full bg-surface-tertiary">
+                <div class="flex-1 h-1 rounded-full bg-white/[0.08]">
                   <div
-                    class="h-2 rounded-full transition-all"
-                    :class="graphStore.selectedNode.progress < 0.3 ? 'bg-danger' : graphStore.selectedNode.progress < 0.7 ? 'bg-warning' : 'bg-success'"
+                    class="h-1 rounded-full bg-[#F4C84A] transition-all"
                     :style="{ width: Math.round(graphStore.selectedNode.progress * 100) + '%' }"
                   />
                 </div>
-                <span class="text-micro text-base-muted">{{ Math.round(graphStore.selectedNode.progress * 100) }}%</span>
+                <span class="text-xs text-white/55">{{ Math.round(graphStore.selectedNode.progress * 100) }}%</span>
               </div>
               <div class="flex gap-4 text-micro text-base-muted">
                 <span>{{ graphStore.selectedNode.flashcards_count }} cards</span>

--- a/app/components/topic/HubNotesTab.vue
+++ b/app/components/topic/HubNotesTab.vue
@@ -14,14 +14,14 @@
             placeholder="Cole seu material de estudo aqui..."
             @keydown.stop
           />
-          <button type="submit" class="btn-primary !py-2 !px-3.5 !min-h-[2.75rem] text-small shrink-0" :disabled="!quickText.trim()">
-            Adicionar
+          <button type="submit" class="btn-secondary !py-2 !px-3.5 !min-h-[2.75rem] !bg-white/[0.06] hover:!bg-white/[0.1] text-sm shrink-0" :disabled="!quickText.trim()">
+            + Adicionar
           </button>
         </form>
 
         <!-- Generate suggestion banner -->
-        <div v-if="suggestGenerate" class="mb-4 px-4 py-3 rounded-xl bg-accent-primary-subtle border border-accent-primary/15 flex items-center justify-between gap-3">
-          <p class="text-small text-accent-primary">Material salvo. Gerar cards com IA?</p>
+        <div v-if="suggestGenerate" class="mb-4 px-4 py-3 rounded-xl bg-[#4B007D]/80 backdrop-blur-sm border border-white/10 flex items-center justify-between gap-3">
+          <p class="text-small text-baigi-text">Material salvo. Gerar cards com IA?</p>
           <div class="flex gap-2">
             <button class="btn-primary !py-1.5 !px-3 !min-h-0 text-small" @click="$emit('generate-from-note', 5); suggestGenerate = false">Gerar</button>
             <button class="btn-secondary !py-1.5 !px-3 !min-h-0 text-small" @click="suggestGenerate = false">Depois</button>

--- a/app/components/topic/TreeItem.vue
+++ b/app/components/topic/TreeItem.vue
@@ -2,7 +2,7 @@
   <div>
     <button
       class="w-full flex items-center gap-2 px-3 py-2.5 rounded-lg text-left text-body transition-colors"
-      :class="topic.id === selectedId ? 'bg-accent-primary-subtle text-accent-primary' : 'text-base-secondary hover:bg-surface-tertiary'"
+      :class="topic.id === selectedId ? 'bg-white/10 text-baigi-text font-medium' : 'text-white/60 hover:bg-white/5 hover:text-white/80'"
       :style="{ paddingLeft: `${depth * 16 + 12}px` }"
       @click="$emit('select', topic.id)"
       @mouseenter="isHovered = true"
@@ -10,7 +10,7 @@
     >
       <button
         v-if="topic.children?.length"
-        class="shrink-0 p-1.5 rounded hover:bg-surface-tertiary"
+        class="shrink-0 p-1.5 rounded hover:bg-white/10 text-white/40"
         @click.stop="expanded = !expanded"
       >
         <ChevronRight :size="14" class="transition-transform" :class="{ 'rotate-90': expanded }" />
@@ -32,13 +32,13 @@
 
       <!-- Actions (visible on hover/selected) -->
       <span v-if="showActions" class="flex items-center gap-0.5 shrink-0" @click.stop>
-        <button class="p-2 rounded hover:bg-surface-tertiary" title="Adicionar tópico" @click="$emit('add-child', topic.id)">
+        <button class="p-2 rounded text-white/40 hover:text-white hover:bg-white/10" title="Adicionar tópico" @click="$emit('add-child', topic.id)">
           <Plus :size="14" />
         </button>
-        <button class="p-2 rounded hover:bg-surface-tertiary" title="Editar" @click="$emit('edit', topic)">
+        <button class="p-2 rounded text-white/40 hover:text-white hover:bg-white/10" title="Editar" @click="$emit('edit', topic)">
           <Pencil :size="14" />
         </button>
-        <button class="p-2 rounded hover:bg-surface-tertiary text-danger" title="Deletar" @click="$emit('delete', topic)">
+        <button class="p-2 rounded text-white/40 hover:text-red-400 hover:bg-white/10" title="Deletar" @click="$emit('delete', topic)">
           <Trash2 :size="14" />
         </button>
       </span>
@@ -86,9 +86,9 @@ const showActions = computed(() => isHovered.value || props.topic.id === props.s
 
 const healthColor = computed(() => {
   const p = props.progressMap?.[props.topic.id]
-  if (p === undefined) return 'bg-[#6B7280]'
-  if (p < 0.3) return 'bg-danger'
-  if (p < 0.7) return 'bg-warning'
-  return 'bg-success'
+  if (p === undefined) return 'bg-white/20'
+  if (p < 0.3) return 'bg-red-400/70'
+  if (p < 0.7) return 'bg-[#F4C84A]/70'
+  return 'bg-[#F4C84A]'
 })
 </script>

--- a/app/components/ui/ActivationChecklist.vue
+++ b/app/components/ui/ActivationChecklist.vue
@@ -5,11 +5,11 @@
       <div v-for="item in items" :key="item.key" class="flex items-center gap-2.5">
         <span
           class="w-5 h-5 rounded-full flex items-center justify-center text-micro shrink-0"
-          :class="item.done ? 'bg-success text-white' : 'border-2 border-base'"
+          :class="item.done ? 'bg-baigi-primary text-[#1A0033]' : 'border-2 border-white/20'"
         >
           <span v-if="item.done">✓</span>
         </span>
-        <span class="text-small" :class="item.done ? 'text-base-muted line-through' : 'text-base-primary'">
+        <span class="text-small" :class="item.done ? 'text-base-muted line-through' : 'text-baigi-text'">
           {{ item.label }}
         </span>
       </div>

--- a/app/components/ui/QuickCapture.vue
+++ b/app/components/ui/QuickCapture.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Trigger button -->
     <button
-      class="fixed z-40 bg-surface-secondary border border-base rounded-full p-3 shadow-lg hover:border-accent-primary hover:scale-105 transition-all right-4 hidden sm:block"
+      class="fixed z-40 bg-white/[0.08] border border-white/[0.1] rounded-full p-3 shadow-lg hover:bg-white/[0.12] transition-all right-4 hidden sm:block text-white/70 hover:text-white"
       :class="isOpen ? '!hidden' : ''"
       style="bottom: 80px;"
       title="Anotar rapidamente (Ctrl+N)"

--- a/app/components/ui/Sidebar.vue
+++ b/app/components/ui/Sidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="hidden lg:flex flex-col bg-surface-secondary h-screen fixed left-0 top-0 w-[220px] p-4">
+  <aside class="hidden lg:flex flex-col bg-[#0A0017] border-r border-white/[0.04] h-screen fixed left-0 top-0 w-[220px] p-4">
     <NuxtLink to="/hoje" class="mb-8 group">
       <UiLogo :icon-size="28" text-class="text-xl font-semibold text-white dark:text-white text-slate-800" />
     </NuxtLink>
@@ -10,7 +10,7 @@
         :key="item.to"
         :to="item.to"
         class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-small transition-all duration-150"
-        :class="isActive(item.to) ? 'bg-[rgba(217,119,6,0.12)] text-accent-primary font-medium shadow-[inset_2px_0_0_#D97706]' : 'text-base-muted opacity-70 hover:opacity-100 hover:text-base-secondary hover:bg-surface-tertiary'"
+        :class="isActive(item.to) ? 'bg-white/[0.05] text-baigi-text font-medium border-l-2 border-l-[#F4C84A]' : 'text-white/50 hover:text-white/70 hover:bg-white/[0.04]'"
         :aria-current="isActive(item.to) ? 'page' : undefined"
         :data-tour="item.to === '/revisar' ? 'review-link' : undefined"
       >

--- a/app/composables/useButton.ts
+++ b/app/composables/useButton.ts
@@ -1,0 +1,32 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { twMerge } from 'tailwind-merge'
+
+export const buttonVariants = cva({
+  base: 'inline-flex items-center justify-center gap-2 font-medium text-sm rounded-xl min-h-[2.75rem] transition-all duration-150 ease-in-out cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:transform-none',
+  variants: {
+    intent: {
+      primary: 'btn-primary',
+      secondary: 'btn-secondary',
+      ghost: 'btn-ghost',
+      danger: 'btn-danger',
+    },
+    size: {
+      sm: 'px-3 py-1.5 text-xs min-h-[2rem]',
+      md: 'px-5 py-2.5',
+      lg: 'px-6 py-3 text-base min-h-[3rem]',
+    },
+    fullWidth: {
+      true: 'w-full',
+    },
+  },
+  defaultVariants: {
+    intent: 'primary',
+    size: 'md',
+  },
+})
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>
+
+export function useButton(intent?: ButtonVariants['intent'], size?: ButtonVariants['size'], fullWidth?: boolean, className?: string) {
+  return twMerge(buttonVariants({ intent, size, fullWidth }), className)
+}

--- a/app/composables/useGraph.ts
+++ b/app/composables/useGraph.ts
@@ -24,7 +24,7 @@ function nodeRadius(d: D3Node): number {
 function nodeColor(d: D3Node): string {
   if (d.flashcards_count === 0) return '#706B64' // warm muted
   if (d.progress < 0.3) return '#EF4444' // red danger
-  if (d.progress < 0.7) return '#D97706' // amber active
+  if (d.progress < 0.7) return '#F4C84A' // gold active
   return '#22C55E' // green mastered
 }
 
@@ -83,11 +83,12 @@ export function useGraph(
       .attr('width', width)
       .attr('height', height)
 
-    // Zoom
+    // Zoom (smaller steps for smoother control)
     const g = svg.append('g')
     svg.call(
       d3.zoom<SVGSVGElement, unknown>()
-        .scaleExtent([0.2, 4])
+        .scaleExtent([0.3, 3])
+        .wheelDelta((event: WheelEvent) => -event.deltaY * 0.002)
         .on('zoom', (event) => {
           g.attr('transform', event.transform)
         }),

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,22 +1,17 @@
 <template>
-  <div class="min-h-screen bg-surface">
+  <div class="min-h-screen bg-[#0F001F]">
     <UiPaymentBanner />
     <UiSidebar />
     <UiBottomNav />
 
-    <main class="lg:ml-[220px] relative" :class="mainPadding">
-      <div class="absolute top-3 z-10" :class="showThemeToggle === 'side' ? 'right-3' : 'left-1/2 -translate-x-1/2'">
-        <button
-          class="p-2 rounded-lg text-base-muted hover:text-accent-primary hover:bg-surface-tertiary/50 transition-colors"
-          :title="colorMode === 'dark' ? 'Modo claro' : 'Modo escuro'"
-          aria-label="Alternar tema"
-          @click="toggle"
-        >
-          <Sun v-if="colorMode === 'dark'" :size="20" :stroke-width="1.5" />
-          <Moon v-else :size="20" :stroke-width="1.5" />
-        </button>
+    <main class="lg:ml-[220px] relative min-h-screen overflow-hidden" :class="mainPadding">
+      <!-- Ambient Glow (subtle — atmosphere, not UI) -->
+      <div class="absolute -top-48 -left-48 w-[500px] h-[500px] rounded-full bg-[#B96A3D] blur-[180px] opacity-[0.12] pointer-events-none z-0" aria-hidden="true" />
+      <div class="absolute -bottom-48 -right-48 w-[400px] h-[400px] rounded-full bg-[#4B007D] blur-[180px] opacity-[0.12] pointer-events-none z-0" aria-hidden="true" />
+
+      <div class="relative z-10">
+        <slot />
       </div>
-      <slot />
     </main>
 
     <UiToast
@@ -41,21 +36,11 @@
 </template>
 
 <script setup lang="ts">
-import { Sun, Moon } from 'lucide-vue-next'
-
 const toast = useToast()
-const { colorMode, toggle } = useColorMode()
 const route = useRoute()
-
-const showThemeToggle = computed(() => {
-  const path = route.path
-  if (path === '/revisar' || path === '/grafo') return 'side'
-  return 'center'
-})
 
 const player = usePlayerStore()
 const hasMiniplayer = computed(() => !!player.currentPodcast)
-// pb-20 = bottom nav (mobile), +16 = miniplayer extra space
 const mainPadding = computed(() => {
   if (hasMiniplayer.value) return 'pb-36 lg:pb-20'
   return 'pb-20 lg:pb-0'

--- a/app/middleware/dev-only.ts
+++ b/app/middleware/dev-only.ts
@@ -1,0 +1,5 @@
+export default defineNuxtRouteMiddleware(() => {
+  if (import.meta.prod) {
+    return navigateTo('/hoje')
+  }
+})

--- a/app/pages/cadernos/index.vue
+++ b/app/pages/cadernos/index.vue
@@ -2,7 +2,7 @@
   <div class="flex h-[calc(100vh-64px)]">
     <!-- Sidebar: Topic tree (desktop: inline, mobile: overlay) -->
     <aside
-      class="border-r border-base flex flex-col shrink-0 transition-all duration-200 bg-surface"
+      class="border-r border-white/[0.04] flex flex-col shrink-0 transition-all duration-200 bg-[#0A0017]"
       :class="[
         sidebarCollapsed ? 'w-0 overflow-hidden' : 'w-72',
         'max-lg:fixed max-lg:inset-0 max-lg:z-40 max-lg:w-full max-lg:border-r-0',
@@ -11,12 +11,12 @@
     >
       <div class="p-3 sm:p-4 border-b border-base">
         <div class="flex items-center justify-between mb-3">
-          <h2 class="text-body font-semibold text-base-primary">Cadernos</h2>
+          <h2 class="text-sm font-semibold text-baigi-text">Cadernos</h2>
           <div class="flex items-center gap-1">
-            <button class="p-1 rounded-lg text-base-muted hover:text-accent-primary hover:bg-surface-tertiary transition-colors lg:hidden" title="Fechar" @click="sidebarOpen = false">
+            <button class="p-1 rounded-lg text-white/40 hover:text-white hover:bg-white/10 transition-colors lg:hidden" title="Fechar" @click="sidebarOpen = false">
               <X :size="16" />
             </button>
-            <button class="p-1 rounded-lg text-base-muted hover:text-accent-primary hover:bg-surface-tertiary transition-colors max-lg:hidden" title="Recolher painel" @click="sidebarCollapsed = true">
+            <button class="p-1 rounded-lg text-white/40 hover:text-white hover:bg-white/10 transition-colors max-lg:hidden" title="Recolher painel" @click="sidebarCollapsed = true">
               <PanelLeftClose :size="16" />
             </button>
           </div>
@@ -36,7 +36,7 @@
             >
               <Network :size="16" /> Mapa
             </button>
-            <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 rounded-lg bg-surface-secondary border border-base shadow-lg text-micro text-base-muted whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+            <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 rounded-lg bg-[#1E0F35] border border-white/[0.06] shadow-lg text-micro text-white/60 whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
               Disponível com 5+ cadernos ({{ topicStore.tree?.length ?? 0 }}/5)
             </span>
           </div>
@@ -44,14 +44,14 @@
             <button class="btn-secondary !py-2 !px-3.5 !min-h-[2.75rem] text-small w-full justify-center" data-tour="create-notebook" @click="showAddMenu = !showAddMenu">
               <Plus :size="16" /> Novo
             </button>
-            <div v-if="showAddMenu" class="absolute right-0 top-full mt-1 w-52 bg-surface-secondary border border-base rounded-lg shadow-lg py-1 z-20">
-              <button class="w-full text-left px-3 py-2 text-small hover:bg-surface-tertiary transition-colors" @click="showAddMenu = false; openCreate(null)">
+            <div v-if="showAddMenu" class="absolute right-0 top-full mt-1 w-52 bg-[#1E0F35] border border-white/[0.06] rounded-xl shadow-lg py-1 z-20">
+              <button class="w-full text-left px-3 py-2 text-small text-baigi-text hover:bg-white/10 transition-colors" @click="showAddMenu = false; openCreate(null)">
                 Novo caderno
               </button>
-              <NuxtLink to="/importar" class="block px-3 py-2 text-small hover:bg-surface-tertiary transition-colors" @click="showAddMenu = false">
+              <NuxtLink to="/importar" class="block px-3 py-2 text-small text-baigi-text hover:bg-white/10 transition-colors" @click="showAddMenu = false">
                 Importar Anki
               </NuxtLink>
-              <button class="w-full text-left px-3 py-2 text-small hover:bg-surface-tertiary transition-colors" @click="showAddMenu = false; triggerStructureUpload()">
+              <button class="w-full text-left px-3 py-2 text-small text-baigi-text hover:bg-white/10 transition-colors" @click="showAddMenu = false; triggerStructureUpload()">
                 <span class="block">Organizar PDF</span>
                 <span class="block text-micro text-base-muted">A IA lê o PDF e monta cadernos e tópicos pra você</span>
               </button>
@@ -62,9 +62,9 @@
       </div>
 
       <!-- Structure generating banner -->
-      <div v-if="structureGenerating" class="mx-3 mb-2 px-3 py-2.5 rounded-lg bg-accent-primary-subtle flex items-center gap-2">
-        <div class="w-4 h-4 border-2 border-accent-primary border-t-transparent rounded-full animate-spin shrink-0" />
-        <p class="text-micro text-accent-primary">Lendo o PDF e organizando cadernos...</p>
+      <div v-if="structureGenerating" class="mx-3 mb-2 px-3 py-2.5 rounded-lg bg-white/5 border border-white/10 flex items-center gap-2">
+        <div class="w-4 h-4 border-2 border-[#F4C84A] border-t-transparent rounded-full animate-spin shrink-0" />
+        <p class="text-micro text-baigi-text">Lendo o PDF e organizando cadernos...</p>
       </div>
 
       <div class="flex-1 overflow-y-auto p-2">
@@ -85,10 +85,10 @@
     </aside>
 
     <!-- Main: Topic Hub -->
-    <main class="flex-1 flex flex-col overflow-y-auto pb-20 lg:pb-0" style="background: radial-gradient(circle at top, rgba(217,119,6,0.04), transparent 60%);">
+    <main class="flex-1 flex flex-col overflow-y-auto pb-20 lg:pb-0">
       <template v-if="selectedTopicId">
         <!-- Topic header -->
-        <div ref="headerRef" class="p-5 border-b border-base bg-surface-secondary/50">
+        <div ref="headerRef" class="p-5 border-b border-white/5">
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2 min-w-0">
               <button
@@ -107,7 +107,7 @@
                 <PanelLeftOpen :size="16" />
               </button>
               <div class="min-w-0">
-                <h2 class="text-headline truncate">{{ selectedTopicName }}</h2>
+                <h2 class="font-heading font-bold text-xl text-baigi-text truncate">{{ selectedTopicName }}</h2>
                 <p v-if="topicCards.length" class="text-small text-base-muted mt-0.5">
                   {{ memorizeProgress > 0 ? memorizeProgress + '% dominado · ' : '' }}{{ topicCards.length }} card{{ topicCards.length !== 1 ? 's' : '' }}
                 </p>
@@ -118,10 +118,9 @@
           <!-- Progress bar -->
           <div v-if="topicCards.length" class="mt-3">
             <div class="flex items-center gap-3">
-              <div class="flex-1 h-2.5 rounded-full bg-surface-tertiary overflow-hidden">
+              <div class="flex-1 h-1 rounded-full bg-white/[0.06] overflow-hidden">
                 <div
-                  class="h-2.5 rounded-full transition-all duration-500"
-                  :class="memorizeProgress < 30 ? 'bg-danger' : memorizeProgress < 70 ? 'bg-warning' : 'bg-success'"
+                  class="h-1 rounded-full bg-[#F4C84A]/[0.65] transition-all duration-500"
                   :style="{ width: memorizeProgress + '%' }"
                 />
               </div>
@@ -134,7 +133,7 @@
             <button
               v-for="sub in subTopics"
               :key="sub.id"
-              class="text-small px-2.5 py-1 rounded-full bg-surface-tertiary text-base-muted hover:text-accent-primary hover:bg-accent-primary-subtle transition-colors"
+              class="text-sm px-2.5 py-1 rounded-full bg-white/[0.06] text-white/[0.65] border border-white/[0.06] hover:bg-white/[0.08] hover:text-white/80 transition-colors"
               @click="selectTopic(sub.id)"
             >
               {{ sub.name }}
@@ -144,9 +143,9 @@
         </div>
 
         <!-- HERO — simple: pending cards + review button -->
-        <div v-if="pendingCount > 0" class="mx-4 mt-5 mb-3 px-6 py-5 rounded-2xl bg-surface-secondary flex items-center justify-between gap-4">
+        <div v-if="pendingCount > 0" class="mx-4 mt-5 mb-3 px-6 py-5 rounded-2xl bg-[#1A0C2E] border border-white/[0.06] flex items-center justify-between gap-4">
           <div>
-            <p class="text-headline text-base-primary">{{ pendingCount }} card{{ pendingCount !== 1 ? 's' : '' }} pendente{{ pendingCount !== 1 ? 's' : '' }}</p>
+            <p class="font-heading font-semibold text-xl text-baigi-text">{{ pendingCount }} card{{ pendingCount !== 1 ? 's' : '' }} pendente{{ pendingCount !== 1 ? 's' : '' }}</p>
             <p class="text-small text-base-muted mt-1">Continue seu progresso de hoje</p>
           </div>
           <div class="flex items-center gap-2 shrink-0">
@@ -159,13 +158,13 @@
 
         <!-- Podcast generate button -->
         <div v-if="selectedTopicId" class="mx-4 mb-3" :class="pendingCount <= 0 ? 'mt-5' : ''">
-          <button class="w-full flex items-center gap-3 px-4 py-3 rounded-xl bg-surface-secondary border border-base hover:border-accent-primary/30 transition-colors text-left" @click="showPodcastSheet = true">
-            <span class="text-xl">🎙️</span>
+          <button class="w-full flex items-center gap-3 px-4 py-3 rounded-xl bg-[#1A0C2E] border border-[rgba(244,200,74,0.12)] hover:border-[rgba(244,200,74,0.25)] hover:bg-white/[0.03] transition-all text-left" @click="showPodcastSheet = true">
+            <span class="text-xl">🎧</span>
             <div class="flex-1">
-              <p class="text-small text-base-primary">Gerar podcast deste caderno</p>
-              <p class="text-micro text-base-muted">Ouça seus pontos fracos</p>
+              <p class="text-sm text-baigi-text font-medium">Revisar ouvindo seus erros</p>
+              <p class="text-xs text-white/45">Podcast personalizado baseado no que você errou</p>
             </div>
-            <span class="text-base-muted text-small">→</span>
+            <span class="text-white/30 text-sm">→</span>
           </button>
         </div>
 

--- a/app/pages/design-system.vue
+++ b/app/pages/design-system.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['dev-only'],
+  layout: false,
+})
+
+const buttons = ['primary', 'secondary', 'ghost', 'danger'] as const
+const sizes = ['sm', 'md', 'lg'] as const
+</script>
+
+<template>
+  <div class="min-h-screen bg-baigi-gradient p-8">
+    <div class="mx-auto max-w-4xl space-y-12">
+      <!-- Header -->
+      <header>
+        <h1 class="text-display text-baigi-text">BAIGI Design System</h1>
+        <p class="text-body text-baigi-text/60 mt-2">Living styleguide — dev only</p>
+      </header>
+
+      <!-- Colors -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Cores</h2>
+        <div class="grid grid-cols-2 gap-4 sm:grid-cols-5">
+          <div class="space-y-2">
+            <div class="h-16 rounded-xl bg-baigi-bg border border-white/10" />
+            <p class="text-micro text-baigi-text/60">bg #2B0057</p>
+          </div>
+          <div class="space-y-2">
+            <div class="h-16 rounded-xl bg-baigi-bg-secondary" />
+            <p class="text-micro text-baigi-text/60">secondary #4B007D</p>
+          </div>
+          <div class="space-y-2">
+            <div class="h-16 rounded-xl bg-baigi-primary" />
+            <p class="text-micro text-baigi-text/60">primary #F4C84A</p>
+          </div>
+          <div class="space-y-2">
+            <div class="h-16 rounded-xl bg-baigi-glow" />
+            <p class="text-micro text-baigi-text/60">glow #B96A3D</p>
+          </div>
+          <div class="space-y-2">
+            <div class="h-16 rounded-xl bg-baigi-dark-glow" />
+            <p class="text-micro text-baigi-text/60">dark-glow #5E2D46</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Typography -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Tipografia</h2>
+        <div class="space-y-3">
+          <p class="text-display text-baigi-text">Display — Plus Jakarta Sans 800</p>
+          <p class="text-headline text-baigi-text">Headline — Plus Jakarta Sans 700</p>
+          <p class="text-title text-baigi-text">Title — Inter 600</p>
+          <p class="text-body text-baigi-text">Body — Inter 400</p>
+          <p class="text-small text-baigi-text-muted">Small — Inter 400</p>
+          <p class="text-micro text-baigi-text-muted">Micro — Inter 400</p>
+          <p class="text-label">LABEL — INTER 600 UPPERCASE</p>
+        </div>
+      </section>
+
+      <!-- Buttons -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Botões</h2>
+        <div class="space-y-6">
+          <div v-for="intent in buttons" :key="intent">
+            <p class="text-label mb-2">{{ intent }}</p>
+            <div class="flex items-center gap-3">
+              <button v-for="size in sizes" :key="size" :class="useButton(intent, size)">
+                {{ intent }} {{ size }}
+              </button>
+              <button :class="useButton(intent, 'md')" disabled>
+                disabled
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Cards -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Cards</h2>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div class="card">
+            <p class="text-title text-baigi-text">Card padrão</p>
+            <p class="text-small text-baigi-text-muted mt-1">Superfície secundária com borda sutil</p>
+          </div>
+          <div class="card-interactive">
+            <p class="text-title text-baigi-text">Card interativo</p>
+            <p class="text-small text-baigi-text-muted mt-1">Hover com glow roxo</p>
+          </div>
+          <div class="card-glow">
+            <p class="text-title text-baigi-text">Card glow</p>
+            <p class="text-small text-baigi-text-muted mt-1">Borda accent com sombra</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Inputs -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Inputs</h2>
+        <div class="max-w-md space-y-4">
+          <input class="input-base" placeholder="Input padrão..." />
+          <textarea class="textarea-base" rows="3" placeholder="Textarea..." />
+        </div>
+      </section>
+
+      <!-- Badges -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Badges</h2>
+        <div class="flex flex-wrap gap-2">
+          <span class="badge badge-primary">Primary</span>
+          <span class="badge badge-accent">Accent</span>
+          <span class="badge badge-success">Success</span>
+          <span class="badge badge-danger">Danger</span>
+          <span class="badge badge-warning">Warning</span>
+          <span class="badge badge-muted">Muted</span>
+        </div>
+      </section>
+
+      <!-- Review Buttons -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Botões de Revisão</h2>
+        <div class="grid grid-cols-4 gap-3 max-w-lg">
+          <button class="btn-again">
+            <span class="text-micro">Não lembrei</span>
+          </button>
+          <button class="btn-hard">
+            <span class="text-micro">Difícil</span>
+          </button>
+          <button class="btn-good">
+            <span class="text-micro">Bom</span>
+          </button>
+          <button class="btn-easy">
+            <span class="text-micro">Fácil</span>
+          </button>
+        </div>
+      </section>
+
+      <!-- Glow Effects -->
+      <section>
+        <h2 class="text-headline text-baigi-text mb-4">Efeitos</h2>
+        <div class="flex gap-4">
+          <div class="h-16 w-16 rounded-full bg-baigi-primary glow-primary" />
+          <div class="h-16 w-16 rounded-full bg-baigi-accent glow-accent" />
+          <div class="h-4 w-32 rounded-full skeleton mt-6" />
+        </div>
+      </section>
+    </div>
+  </div>
+</template>

--- a/app/pages/hoje.vue
+++ b/app/pages/hoje.vue
@@ -3,15 +3,15 @@
     <!-- Greeting + Streak -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
       <div>
-        <h1 class="text-display">
+        <h1 class="font-heading font-bold text-3xl text-baigi-text">
           {{ greeting }}, <span class="text-accent-primary opacity-85">{{ auth.user?.name?.split(' ')[0] ?? 'estudante' }}</span>
         </h1>
         <p class="text-base-muted mt-1">Vamos manter seu ritmo hoje.</p>
       </div>
-      <div class="flex items-center gap-2 shrink-0 sm:shrink-0 justify-center sm:justify-start">
-        <span class="text-[2rem] font-semibold text-accent-primary leading-none">{{ stats?.streak ?? 0 }}</span>
+      <div class="flex items-center gap-2 shrink-0 px-3 py-2 rounded-xl bg-white/[0.04]">
+        <span class="text-2xl font-semibold text-baigi-primary leading-none">{{ stats?.streak ?? 0 }}</span>
         <div class="flex flex-col items-start">
-          <span class="text-small text-base-muted">dias 🔥</span>
+          <span class="text-xs text-white/45">dias 🔥</span>
           <UiSparkline v-if="sparklineData.length" :data="sparklineData" :width="60" :height="18" />
         </div>
       </div>
@@ -42,17 +42,18 @@
     </div>
 
     <!-- CTA Hero -->
-    <div v-if="(stats?.due_today ?? 0) > 0 || (backlog?.overdue_count ?? 0) > 0" class="card-warm mt-6 py-5 px-5" style="background: linear-gradient(90deg, rgba(217,119,6,0.06), transparent);">
-      <div class="flex items-center justify-between mb-2">
-        <p class="text-title text-base-primary">🎯 {{ totalCards }} cards para revisar<span v-if="mainTopicName" class="text-base-muted font-normal"> · {{ mainTopicName }}</span></p>
-        <span class="text-small text-base-muted">~{{ backlog?.estimated_minutes ?? Math.ceil(totalCards * 0.25) }} min</span>
+    <div v-if="(stats?.due_today ?? 0) > 0 || (backlog?.overdue_count ?? 0) > 0" class="card-warm mt-6 py-5 px-5">
+      <div class="flex items-center justify-between mb-3">
+        <p class="font-heading font-semibold text-2xl text-baigi-text">🎯 {{ totalCards }} cards para revisar<span class="text-sm text-white/50 font-normal"> · {{ mainTopicName }}</span></p>
+        <span class="text-xs text-white/45">~{{ backlog?.estimated_minutes ?? Math.ceil(totalCards * 0.25) }} min</span>
       </div>
-      <div class="h-3 rounded-full bg-surface-tertiary overflow-hidden mb-3">
-        <div
-          class="h-3 rounded-full transition-all duration-500 ease-out glow-success"
-          :class="progressPercent > 80 ? 'bg-success' : progressPercent > 40 ? 'bg-warning' : 'bg-accent-primary'"
-          :style="{ width: progressPercent + '%' }"
-        />
+      <div class="border-t border-white/[0.06] pt-3 mb-3">
+        <div class="h-1.5 rounded-full bg-white/[0.08] overflow-hidden">
+          <div
+            class="h-1.5 rounded-full bg-baigi-primary transition-all duration-500 ease-out"
+            :style="{ width: progressPercent + '%' }"
+          />
+        </div>
       </div>
       <div class="flex items-center justify-between">
         <span class="text-micro text-base-muted">{{ stats?.reviewed_today ?? 0 }} revisados hoje</span>
@@ -79,23 +80,24 @@
 
     <!-- Seu ritmo + Ações rápidas -->
     <div v-if="stats" class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-      <div class="card md:col-span-2">
+      <div class="card md:col-span-2 h-full flex flex-col justify-between">
         <div class="flex items-center justify-between mb-3">
-          <p class="text-small font-medium text-base-primary">Seu ritmo hoje</p>
+          <p class="text-xs uppercase tracking-wider text-white/45 font-medium">Seu ritmo hoje</p>
+          <span class="text-lg font-semibold text-baigi-text">{{ stats.due_today ?? 0 }} <span class="text-xs font-normal text-white/45">restantes</span></span>
         </div>
-        <div class="h-2 rounded-full bg-surface-tertiary overflow-hidden">
-          <div class="h-2 rounded-full bg-success transition-all duration-500 glow-success" :style="{ width: progressPercent + '%' }" />
+        <div class="h-1 rounded-full bg-white/[0.08] overflow-hidden">
+          <div class="h-1 rounded-full bg-baigi-primary transition-all duration-500" :style="{ width: progressPercent + '%' }" />
         </div>
-        <div class="flex justify-between text-micro text-base-muted mt-2">
-          <span>Faltam: {{ stats.due_today ?? 0 }}</span>
+        <div class="flex justify-between text-xs text-white/45 mt-2">
           <span>{{ stats.reviewed_today ?? 0 }} revisados</span>
+          <span>{{ progressPercent }}%</span>
         </div>
       </div>
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2 h-full">
         <NuxtLink to="/revisar?errors_only=1" class="btn-secondary justify-center text-small flex-1">
           Revisar só erros
         </NuxtLink>
-        <NuxtLink to="/importar" class="btn-accent justify-center text-small flex-1">
+        <NuxtLink to="/importar" class="btn-secondary justify-center text-small flex-1">
           Importar Anki
         </NuxtLink>
       </div>
@@ -114,11 +116,11 @@
     </div>
 
     <!-- Pra hoje (max 3 actions) -->
-    <div v-if="pendingActions.length" class="mt-8">
+    <div v-if="pendingActions.length" class="mt-10">
       <p class="text-label mb-3">Pra hoje</p>
       <div class="space-y-2">
-        <div v-for="action in pendingActions" :key="action.label" class="flex items-center justify-between px-4 py-3 rounded-lg bg-surface-secondary">
-          <span class="text-small text-base-primary">{{ action.label }}</span>
+        <div v-for="action in pendingActions" :key="action.label" class="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-white/[0.03] border border-white/[0.06]">
+          <span class="text-small text-baigi-text truncate min-w-0">{{ action.label }}</span>
           <NuxtLink :to="action.url" class="btn-secondary !py-1 !px-3 !min-h-[2.75rem] text-small shrink-0">
             {{ action.action_label }}
           </NuxtLink>
@@ -127,7 +129,7 @@
     </div>
 
     <!-- Continuar estudando -->
-    <div v-if="topicProgress.length" class="mt-8">
+    <div v-if="topicProgress.length" class="mt-10">
       <p class="text-label mb-3">Continuar estudando</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <NuxtLink
@@ -136,16 +138,15 @@
           :to="`/cadernos?topic=${tp.id}`"
           class="card-interactive"
         >
-          <p class="text-small font-medium text-base-primary truncate">{{ tp.name }}</p>
+          <p class="text-small font-medium text-baigi-text truncate">{{ tp.name }}</p>
           <div class="flex items-center gap-2 mt-2">
-            <div class="flex-1 h-1.5 rounded-full bg-surface-tertiary">
+            <div class="flex-1 h-1 rounded-full bg-white/[0.06]">
               <div
-                class="h-1.5 rounded-full transition-all"
-                :class="tp.progress < 0.3 ? 'bg-danger' : tp.progress < 0.7 ? 'bg-warning' : 'bg-success'"
+                class="h-1 rounded-full bg-baigi-primary transition-all"
                 :style="{ width: Math.round(tp.progress * 100) + '%' }"
               />
             </div>
-            <span class="text-micro text-base-muted">{{ Math.round(tp.progress * 100) }}%</span>
+            <span class="text-xs text-white/50">{{ Math.round(tp.progress * 100) }}%</span>
           </div>
           <p class="text-micro text-base-muted mt-1">{{ tp.flashcards_count }} cards</p>
         </NuxtLink>
@@ -153,7 +154,7 @@
     </div>
 
     <!-- Activation checklist -->
-    <div v-if="stats" class="mt-8">
+    <div v-if="stats" class="mt-10">
       <!-- debug -->
       <UiActivationChecklist
         :has-topics="Number(stats.total_decks) > 0"
@@ -165,16 +166,15 @@
     </div>
 
     <!-- AI Usage -->
-    <div v-if="featureUsage.usage.value && hasLimitedFeatures" class="mt-8">
+    <div v-if="featureUsage.usage.value && hasLimitedFeatures" class="mt-10">
       <p class="text-label mb-3">Uso de IA este mês</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
         <div v-for="(data, key) in limitedFeatures" :key="key" class="card py-3 px-4">
           <p class="text-micro text-base-muted mb-1">{{ featureLabels[key] }}</p>
           <p class="text-title text-base-primary">{{ data.used }}/{{ data.limit }}</p>
-          <div class="h-1.5 rounded-full bg-surface-tertiary mt-2 overflow-hidden">
+          <div class="h-1 rounded-full bg-white/[0.06] mt-2 overflow-hidden">
             <div
-              class="h-1.5 rounded-full transition-all"
-              :class="data.remaining === 0 ? 'bg-danger' : data.used / data.limit > 0.8 ? 'bg-warning' : 'bg-accent-primary'"
+              class="h-1 rounded-full bg-baigi-primary transition-all"
               :style="{ width: Math.min(100, (data.used / data.limit) * 100) + '%' }"
             />
           </div>

--- a/app/pages/importar.vue
+++ b/app/pages/importar.vue
@@ -17,13 +17,13 @@
       </label>
 
       <div
-        class="mt-6 border-2 border-dashed border-surface-tertiary rounded-xl p-8 transition-colors"
-        :class="dragOver ? 'border-accent-primary bg-accent-primary/5' : ''"
+        class="mt-6 border border-white/[0.06] bg-white/[0.02] rounded-xl p-8 transition-all"
+        :class="dragOver ? 'border-[rgba(244,200,74,0.25)] bg-white/[0.04]' : 'hover:border-white/[0.1]'"
         @dragover.prevent="dragOver = true"
         @dragleave="dragOver = false"
         @drop.prevent="handleDrop"
       >
-        <p class="text-small text-base-muted">ou arraste e solte aqui</p>
+        <p class="text-sm text-white/[0.55]">ou arraste e solte aqui</p>
       </div>
     </div>
 

--- a/app/pages/podcasts.vue
+++ b/app/pages/podcasts.vue
@@ -2,8 +2,8 @@
   <div class="p-4 sm:p-6 pb-20 lg:pb-6 max-w-3xl mx-auto">
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-display">Podcasts</h1>
-        <p class="text-small text-base-muted mt-1">Sua biblioteca de revisão em áudio</p>
+        <h1 class="font-heading font-bold text-3xl text-baigi-text">Podcasts</h1>
+        <p class="text-sm text-white/55 mt-1">Sua biblioteca de revisão em áudio</p>
       </div>
       <button class="btn-primary" @click="showGenerate = true">
         🎙️ Gerar podcast
@@ -30,21 +30,21 @@
     <!-- Podcast list grouped by topic -->
     <template v-else>
       <!-- Currently playing -->
-      <div v-if="player.currentPodcast" class="mb-6">
-        <p class="text-micro text-accent-primary uppercase tracking-wide mb-3">Tocando agora</p>
+      <div v-if="player.currentPodcast" class="mb-8">
+        <p class="text-label mb-3">Tocando agora</p>
         <div
-          class="w-full card flex items-center gap-4 border-accent-primary/30 hover:border-accent-primary/50 transition-colors text-left cursor-pointer"
+          class="w-full rounded-2xl bg-gradient-to-b from-[#2A1550] to-[#1A0C2E] border border-white/[0.08] p-5 flex items-center gap-4 hover:border-white/[0.12] transition-colors cursor-pointer shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
           @click="player.expand()"
         >
-          <div class="w-12 h-12 rounded-xl bg-accent-primary/15 flex items-center justify-center shrink-0">
-            <div class="w-3 h-3 rounded-full bg-accent-primary animate-pulse" />
+          <div class="w-14 h-14 rounded-xl bg-[rgba(244,200,74,0.12)] border border-[rgba(244,200,74,0.2)] flex items-center justify-center shrink-0">
+            <div class="w-3 h-3 rounded-full bg-[#F4C84A] animate-pulse" />
           </div>
           <div class="flex-1 min-w-0">
-            <p class="text-small text-base-primary font-medium truncate">{{ player.currentPodcast.title }}</p>
-            <p class="text-micro text-base-muted">{{ formatTime(player.currentTime) }} / {{ formatTime(player.duration) }}</p>
+            <p class="text-sm text-baigi-text font-medium truncate">{{ player.currentPodcast.title }}</p>
+            <p class="text-xs text-white/55 mt-0.5">{{ formatTime(player.currentTime) }} / {{ formatTime(player.duration) }}</p>
           </div>
           <button
-            class="w-9 h-9 rounded-full bg-accent-primary flex items-center justify-center shrink-0"
+            class="w-10 h-10 rounded-full bg-[#F4C84A] flex items-center justify-center shrink-0 hover:brightness-110 transition-all"
             @click.stop="player.togglePlay()"
           >
             <Pause v-if="player.isPlaying" :size="16" class="text-white" />
@@ -64,11 +64,11 @@
           >
             <!-- Status icon -->
             <div class="w-11 h-11 rounded-xl flex items-center justify-center shrink-0" :class="statusBg(podcast.status)">
-              <Loader2 v-if="isGenerating(podcast.status)" :size="18" class="animate-spin" :class="statusText(podcast.status)" />
-              <AlertCircle v-else-if="podcast.status === 'failed'" :size="18" class="text-danger" />
+              <Loader2 v-if="isGenerating(podcast.status)" :size="18" class="animate-spin text-white/50" />
+              <AlertCircle v-else-if="podcast.status === 'failed'" :size="18" class="text-red-400" />
               <button v-else @click="playPodcast(podcast)" class="w-full h-full flex items-center justify-center">
                 <Pause v-if="player.currentPodcast?.id === podcast.id && player.isPlaying" :size="18" :class="statusText(podcast.status)" />
-                <Play v-else :size="18" :class="statusText(podcast.status)" class="ml-0.5" />
+                <Headphones v-else :size="18" :class="statusText(podcast.status)" />
               </button>
             </div>
 
@@ -136,14 +136,14 @@ function isGenerating(status: string) {
 }
 
 function statusBg(status: string) {
-  if (status === 'ready') return 'bg-accent-primary/10'
-  if (status === 'failed') return 'bg-danger/10'
-  return 'bg-surface-tertiary'
+  if (status === 'ready') return 'bg-[rgba(244,200,74,0.08)]'
+  if (status === 'failed') return 'bg-red-500/10'
+  return 'bg-white/[0.04]'
 }
 
 function statusText(status: string) {
-  if (status === 'ready') return 'text-accent-primary'
-  return 'text-base-muted'
+  if (status === 'ready') return 'text-[#F4C84A]'
+  return 'text-white/50'
 }
 
 function statusLabel(status: string): string {

--- a/app/pages/revisar.vue
+++ b/app/pages/revisar.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="review-bg h-[calc(100vh-56px)] flex flex-col overflow-y-auto">
+  <div class="review-bg h-[calc(100vh-56px)] flex flex-col overflow-hidden">
     <!-- Top bar — minimal -->
     <div class="flex items-center justify-between px-4 py-3">
-      <NuxtLink to="/hoje" class="text-small text-base-muted opacity-60 hover:opacity-100 hover:text-accent-primary transition-opacity">
+      <NuxtLink to="/hoje" class="text-sm text-white/55 hover:text-white transition-opacity">
         ← Voltar
       </NuxtLink>
       <div class="flex items-center gap-3 text-small text-base-muted">
@@ -18,17 +18,17 @@
     </div>
 
     <!-- Progress bar — thin, with pulse on update -->
-    <div class="w-full h-[3px] bg-black/5 dark:bg-[rgba(255,255,255,0.06)]">
+    <div class="w-full h-[3px] bg-white/[0.06]">
       <div
-        class="h-[3px] transition-all duration-500 ease-out"
+        class="h-[3px] transition-all duration-500 ease-out bg-baigi-primary"
         :class="progressPulse ? 'progress-pulse' : ''"
-        :style="{ width: review.progress + '%', background: 'linear-gradient(90deg, #B45309, #D97706, #F59E0B)' }"
+        :style="{ width: review.progress + '%' }"
       />
     </div>
 
     <!-- Micro reward toast -->
     <Transition name="reward-pop">
-      <div v-if="rewardMessage" class="fixed top-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-surface-secondary border border-success/20 text-small text-success shadow-lg">
+      <div v-if="rewardMessage" class="fixed top-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-[#150A25] border border-[rgba(244,200,74,0.2)] text-sm text-baigi-primary shadow-lg">
         {{ rewardMessage }}
       </div>
     </Transition>
@@ -104,16 +104,11 @@
     </div>
 
     <!-- Review -->
-    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 pt-6 gap-10">
+    <div v-else-if="review.currentCard" class="flex-1 flex flex-col items-center justify-center px-4 gap-4">
       <!-- State badge -->
       <div v-if="review.currentCard.is_learning || review.currentCard.state === 'new'" class="flex items-center gap-2">
         <span
-          class="px-3 py-1 rounded-full text-micro tracking-wide uppercase font-medium"
-          :class="{
-            'bg-orange-500/15 text-orange-400': review.currentCard.state === 'relearning',
-            'bg-blue-500/15 text-blue-400': review.currentCard.state === 'learning',
-            'bg-emerald-500/15 text-emerald-400': review.currentCard.state === 'new',
-          }"
+          class="px-3 py-1 rounded-full text-xs tracking-wide uppercase font-medium bg-white/[0.06] border border-white/[0.08] text-white/60"
         >
           {{ review.currentCard.state === 'relearning' ? '🔄 Reaprendendo' : review.currentCard.state === 'new' ? '✨ Novo' : '📖 Aprendendo' }}
         </span>
@@ -127,12 +122,34 @@
       />
 
       <FlashcardButtons
-        v-if="review.flipped"
-        class="sticky bottom-4 z-10"
+        v-if="review.flipped && !review.showErrorDiary"
+        class="mt-4"
         :disabled="review.submitting"
         :intervals="review.currentIntervals"
         @rate="handleRate"
       />
+
+      <!-- Error diary (replaces buttons after error) -->
+      <div v-if="review.showErrorDiary" class="w-full max-w-lg mt-8 space-y-3">
+        <FlashcardErrorDiary
+          :visible="true"
+          :flashcard-id="lastErrorCardId"
+          :review-id="review.lastReviewId ?? ''"
+          @saved="dismissErrorDiary"
+          @skipped="dismissErrorDiary"
+        />
+        <!-- Note snippet -->
+        <div v-if="review.noteSnippet" class="p-3 rounded-lg bg-white/[0.03] border border-white/[0.06]">
+          <p class="text-xs text-[#F4C84A] font-medium mb-1">📝 Da sua nota: {{ review.noteSnippet.title }}</p>
+          <p class="text-sm text-white/70">{{ review.noteSnippet.snippet }}</p>
+        </div>
+        <!-- Actions -->
+        <div class="flex gap-2 justify-center">
+          <button class="btn-secondary !py-1.5 !px-3 !min-h-0 text-sm" @click="openChatForError">
+            ✨ Me explica esse erro
+          </button>
+        </div>
+      </div>
 
       <!-- Weak connection suggestion -->
       <div v-if="review.weakSuggestion?.length && !review.showErrorDiary" class="w-full max-w-lg px-4">
@@ -154,62 +171,6 @@
       <NuxtLink to="/cadernos" class="btn-primary mt-6">Ir pra Cadernos</NuxtLink>
     </div>
 
-    <!-- Error diary -->
-    <div v-if="review.showErrorDiary" class="flex-1 flex flex-col items-center justify-center px-4">
-      <FlashcardErrorDiary
-        :visible="true"
-        :flashcard-id="lastErrorCardId"
-        :review-id="review.lastReviewId ?? ''"
-        @saved="dismissErrorDiary"
-        @skipped="dismissErrorDiary"
-      />
-      <!-- Note snippet (reverse linking) -->
-      <div v-if="review.noteSnippet" class="mt-4 w-full max-w-md p-3 rounded-lg bg-accent-primary-subtle border border-accent-primary/20">
-        <p class="text-micro text-accent-primary font-medium mb-1">📝 Da sua nota: {{ review.noteSnippet.title }}</p>
-        <p class="text-small text-base-secondary">{{ review.noteSnippet.snippet }}</p>
-        <NuxtLink
-          :to="`/cadernos?topic=${review.noteSnippet.topic_id}&note=${review.noteSnippet.note_id}`"
-          class="text-micro text-accent-primary hover:underline mt-1 inline-block"
-        >
-          Ver nota completa →
-        </NuxtLink>
-      </div>
-
-      <!-- Hints from callout blocks -->
-      <div v-if="review.hints.length" class="mt-3 w-full max-w-md space-y-2">
-        <template v-for="(hint, i) in visibleHints" :key="i">
-          <div class="p-3 rounded-lg bg-surface-secondary border border-base-muted/10 flex items-start gap-2">
-            <span class="shrink-0">{{ hintIcon(hint.type) }}</span>
-            <p class="text-small text-base-secondary">{{ hint.text }}</p>
-          </div>
-        </template>
-        <button
-          v-if="review.hints.length > 2 && !showAllHints"
-          class="text-micro text-accent-primary hover:underline"
-          @click="showAllHints = true"
-        >
-          Ver mais {{ review.hints.length - 2 }} dica{{ review.hints.length - 2 !== 1 ? 's' : '' }}
-        </button>
-      </div>
-
-      <!-- Chat trigger after error -->
-      <div class="flex gap-2 mt-3">
-        <button
-          v-if="review.showErrorDiary || review.noteSnippet"
-          class="btn-secondary !py-1.5 !px-3 !min-h-[2.75rem] text-small"
-          @click="openChatForError"
-        >
-          ✨ Entender isso
-        </button>
-        <NuxtLink
-          v-if="review.currentCard?.topic_id && review.currentCard?.source_note_id"
-          :to="`/cadernos?topic=${review.currentCard.topic_id}&note=${review.currentCard.source_note_id}`"
-          class="btn-secondary !py-1.5 !px-3 !min-h-[2.75rem] text-small"
-        >
-          📝 Ver no conteúdo
-        </NuxtLink>
-      </div>
-    </div>
     <!-- Timer expired modal -->
     <UiModal v-model="showTimerModal" size="sm" aria-label="Tempo esgotado">
       <div class="text-center">
@@ -457,23 +418,19 @@ watch(() => route.query, (newQ, oldQ) => {
 
 <style scoped>
 .review-bg {
-  background: #FAFAFA;
+  background: #0F001F;
   color: var(--text-primary);
 }
 
-:where(.dark) .review-bg {
-  background: radial-gradient(ellipse at 50% 45%, #1E1814 0%, #110F0D 40%, #0A0908 70%);
-}
-
 .progress-pulse {
-  box-shadow: 0 0 8px rgba(217, 119, 6, 0.3);
+  box-shadow: 0 0 8px rgba(244, 200, 74, 0.3);
   animation: pulse-glow 0.6s ease;
 }
 
 @keyframes pulse-glow {
-  0% { box-shadow: 0 0 4px rgba(217, 119, 6, 0.1); }
-  50% { box-shadow: 0 0 12px rgba(217, 119, 6, 0.4); }
-  100% { box-shadow: 0 0 4px rgba(217, 119, 6, 0.1); }
+  0% { box-shadow: 0 0 4px rgba(244, 200, 74, 0.1); }
+  50% { box-shadow: 0 0 12px rgba(244, 200, 74, 0.4); }
+  100% { box-shadow: 0 0 4px rgba(244, 200, 74, 0.1); }
 }
 
 .reward-pop-enter-active {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,11 +14,11 @@ export default defineNuxtConfig({
   pwa: {
     registerType: 'autoUpdate',
     manifest: {
-      name: 'Memorai',
-      short_name: 'Memorai',
-      description: 'Memora aí — sua memória com IA',
-      theme_color: '#522A6F',
-      background_color: '#1A1A1D',
+      name: 'BAIGI',
+      short_name: 'BAIGI',
+      description: 'Estude de forma mais inteligente — repetição espaçada com IA',
+      theme_color: '#180838',
+      background_color: '#180838',
       display: 'standalone',
       scope: '/',
       start_url: '/dashboard',
@@ -42,13 +42,13 @@ export default defineNuxtConfig({
 
   app: {
     head: {
-      htmlAttrs: { lang: 'pt-BR', class: 'dark' },
-      title: 'Memorai',
+      htmlAttrs: { lang: 'pt-BR' },
+      title: 'BAIGI',
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { name: 'description', content: 'Memora aí — sua memória com IA' },
-        { name: 'theme-color', content: '#522A6F' },
+        { name: 'description', content: 'Estude de forma mais inteligente — repetição espaçada com IA' },
+        { name: 'theme-color', content: '#180838' },
         { name: 'apple-mobile-web-app-capable', content: 'yes' },
         { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
       ],
@@ -57,7 +57,7 @@ export default defineNuxtConfig({
         { rel: 'apple-touch-icon', href: '/apple-touch-icon.svg' },
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
-        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600&family=Manrope:wght@600;700;800&display=swap' },
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Fredoka:wght@600;700&family=Inter:wght@400;500;600&family=Poppins:wght@600;700;800&display=swap' },
       ],
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/starter-kit": "^3.22.3",
         "@tiptap/vue-3": "^3.22.3",
         "@types/d3": "^7.4.3",
+        "class-variance-authority": "^0.7.1",
         "d3": "^7.9.0",
         "dompurify": "^3.4.2",
         "lucide-vue-next": "^1.0.0",
@@ -25,6 +26,7 @@
         "nuxt": "^4.4.2",
         "pdfjs-dist": "^4.9.155",
         "pinia": "^3.0.4",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -7597,6 +7599,18 @@
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -7609,6 +7623,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -14599,6 +14622,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/starter-kit": "^3.22.3",
     "@tiptap/vue-3": "^3.22.3",
     "@types/d3": "^7.4.3",
+    "class-variance-authority": "^0.7.1",
     "d3": "^7.9.0",
     "dompurify": "^3.4.2",
     "lucide-vue-next": "^1.0.0",
@@ -34,6 +35,7 @@
     "nuxt": "^4.4.2",
     "pdfjs-dist": "^4.9.155",
     "pinia": "^3.0.4",
+    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.2.2"
   },
   "private": true,


### PR DESCRIPTION
## Resumo

Rebrand completo de Memorai → BAIGI com design system v2 (App Mode).

Princípio: **80% neutro + 15% cor + 5% destaque**. Landing = emoção, App = foco.

## Mudanças

### Tokens & Infraestrutura
- Paleta dark-native: `#0F001F` fundo, `#150A25` cards, `#F4C84A` dourado
- Fontes: Poppins (headings) + Inter (body) + Fredoka (logo)
- CVA + tailwind-merge instalados
- Página `/design-system` (dev-only, living styleguide)
- Light mode removido

### Dashboard (`hoje.vue`)
- Card hero com gradiente + border-left dourado + divider interno
- Barras de progresso finas (4px) com fill dourado
- Streak em mini card
- Section labels 11px uppercase

### Cadernos (`cadernos/index.vue`)
- Sidebar `#0A0017` com border-l dourado no ativo
- Tags silenciosas (white/65)
- Podcast card como hero secundário
- Upload zones sem tracejado (ghost card)

### Revisão (`revisar.vue`)
- Card com gradiente DS + border-left dourado suave
- ErrorDiary inline (substitui botões FSRS, nunca empilha)
- Botões FSRS desaturados (Hard/Easy com opacity 0.7)
- Sem scroll (overflow-hidden)

### Podcasts (`podcasts.vue`)
- Hero "Tocando agora" com gradiente + shadow
- Ícones semânticos (🎧 pronto, 🔄 processando, ⚠️ falhou)
- Miniplayer com identidade DS

### Grafo (`GraphOverlay.vue`)
- Cores DS no overlay e panel
- Nó médio usa dourado da marca
- Zoom suave (wheelDelta * 0.002)

### Componentes globais
- Chat FAB: contextual por rota, estilo dourado sutil
- Ambient glow: 12% opacity, blur 180px
- Inputs: bg-black/25 (afundam)
- Scrollbar: white/8

## Testado
- Build ✅ (27 arquivos, 706 inserções, 588 deleções)
- Todas as telas verificadas visualmente

## ADR
- ADR-017 (v2) documenta todas as decisões